### PR TITLE
Streamline home dashboard around pending and live tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ Plataforma moderna para transcribir audios con WhisperX, identificar hablantes, 
 - **Base de datos SQLite / SQLAlchemy** con búsqueda por texto, asignatura y estado.
 - **Generación automática de archivos `.txt`** y estructura extensible para futuros planes premium con IA externa.
 - **Interfaz web** en `/` con selector multimedia animado, validación de audio/video y barra de progreso en tiempo real.
+- **Inicio unificado** que combina subida rápida, transcripción en vivo, vista instantánea con auto-scroll y accesos directos a carpetas y trabajos recientes.
+- **Biblioteca por carpetas** con filtros por etiquetas, estado, número de tema y búsqueda libre para localizar transcripciones rápidas.
 - **Dashboard con métricas en vivo** (totales, completadas, minutos procesados, etc.) y vista estilo ChatGPT con animación adaptativa que escribe según el modelo y el dispositivo usado, desplazando la vista automáticamente.
 - **Beneficios premium simulados** con checkout y confirmación que desbloquean notas IA enriquecidas sin mostrar importes hasta definir tu estrategia comercial.
 - **Selector de idioma** con español (predeterminado), inglés y francés, además de autodetección cuando lo necesites.
+- **Autocompletado de carpetas** que recuerda la última carpeta usada, sugiere destinos existentes y sincroniza el modo en vivo con el formulario principal.
 - **Modo estudiante web**: vista ligera con anuncios educativos y ejecución local accesible en `student.html` o desde el botón “Abrir simulador independiente”.
+- **Transcripción en vivo** que captura audio del navegador, permite elegir modelo/dispositivo y convierte la sesión en una transcripción almacenada con sus TXT generados.
+- **Diagnósticos de CUDA** con eventos de fallback detallados y avisos en la Biblioteca para que puedas corregir drivers o forzar la GPU cuando sea necesario.
 - **Inicio de sesión con Google (OAuth 2.0)** listo para conectar con tus credenciales y personalizar la experiencia del dashboard.
 - **Dockerfile y docker-compose** para ejecutar el servicio completo (API + frontend) y posibilidad de habilitar GPU.
 - **Tests con Pytest** que validan el flujo principal usando un transcriptor simulado y comprueban la compatibilidad con las versiones recientes de faster-whisper.
@@ -193,6 +198,17 @@ Las pruebas activan el transcriptor simulado para validar el ciclo completo sin 
 ## Contenido premium y notas IA
 
 Al confirmar una compra, la API genera notas premium automáticamente (`app/utils/notes.py`). El motor actual resume, destaca ideas y propone próximos pasos de manera heurística, listo para que sustituyas la lógica por tu integración favorita (OpenAI, Azure, etc.) cuando habilites cobros reales.
+
+## Ideas de mejora a corto plazo
+
+- **Persistir filtros personalizados:** guardar en `localStorage` la etiqueta, estado y búsqueda seleccionados en la biblioteca para retomar el contexto al volver a entrar. Esto reduce clics repetitivos cuando trabajas con muchas materias.
+- **Lector de eventos en tiempo real:** exponer un panel cronológico con los `debug_events` más recientes para seguir el progreso sin abrir cada tarjeta. Ayuda a detectar cuellos de botella o fallos de VAD mientras ocurren.
+- **Diagnóstico de dependencias:** detectar avisos como la ausencia de `hf_xet` o la incompatibilidad de `torchaudio` y sugerir la instalación o actualización adecuada desde la interfaz. Prioriza la salud del backend y evita sorpresas en producción.
+- **Acciones masivas en carpetas:** permitir descargar, reintentar o borrar en lote todos los elementos de una carpeta o los que coinciden con un filtro determinado. Acelera la higiene de la biblioteca cuando llegan tandas grandes.
+- **Anotaciones rápidas por asignatura:** guardar notas o recordatorios asociados a cada carpeta/tema para documentar qué falta por repasar. Mantiene el contexto pedagógico en la misma herramienta.
+- **Alertas de calidad en vivo:** añadir métricas de latencia y confianza durante las sesiones de streaming para saber cuándo conviene cambiar de modelo o dispositivo.
+- **Respaldo automático de sesiones en vivo:** subir fragmentos firmados al almacenamiento definitivo mientras se graba para mitigar pérdidas si el navegador se cierra o falla la red.
+- **Resumen incremental por IA:** generar resúmenes parciales conforme se transcribe para dar feedback inmediato a los alumnos y enfocar la revisión en lo importante.
 
 ## Estructura de carpetas
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -108,3 +108,49 @@ class PurchaseDetail(PurchaseResponse):
 
     class Config:
         orm_mode = True
+
+
+class LiveSessionCreateRequest(BaseModel):
+    language: Optional[str] = None
+    model_size: Optional[str] = None
+    device_preference: Optional[str] = None
+
+
+class LiveSessionCreateResponse(BaseModel):
+    session_id: str
+    model_size: str
+    device_preference: str
+    language: Optional[str] = None
+
+
+class LiveChunkResponse(BaseModel):
+    session_id: str
+    text: str
+    duration: Optional[float]
+    runtime_seconds: Optional[float]
+    chunk_count: int
+    model_size: str
+    device_preference: str
+    language: Optional[str]
+
+
+class LiveFinalizeRequest(BaseModel):
+    destination_folder: Optional[str] = None
+    subject: Optional[str] = None
+    language: Optional[str] = None
+    model_size: Optional[str] = None
+    device_preference: Optional[str] = None
+    filename: Optional[str] = None
+
+
+class LiveFinalizeResponse(BaseModel):
+    session_id: str
+    transcription_id: Optional[int]
+    text: str
+    duration: Optional[float]
+    runtime_seconds: Optional[float]
+    output_folder: Optional[str]
+    transcript_path: Optional[str]
+    model_size: Optional[str]
+    device_preference: Optional[str]
+    language: Optional[str]

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -75,9 +75,68 @@ let cachedPlans = [];
 const studentPreviewBody = document.querySelector('#student-preview-body');
 const studentFollowToggle = document.querySelector('#student-follow');
 const openStudentBtn = document.querySelector('#open-student-web');
+const folderGroupsContainer = document.querySelector('#folder-groups');
+const folderCategoryFilter = document.querySelector('#folder-category');
+const folderStatusFilter = document.querySelector('#folder-status');
+const folderTopicFilter = document.querySelector('#folder-topic');
+const folderSearchInput = document.querySelector('#folder-search');
+const folderResetButton = document.querySelector('#folder-reset');
+const systemAlerts = document.querySelector('#system-alerts');
+const destinationOptionsList = document.querySelector('#destination-folder-options');
+const destinationSavedHint = document.querySelector('#destination-saved-hint');
+const liveLanguageSelect = document.querySelector('#live-language');
+const liveModelSelect = document.querySelector('#live-model');
+const liveDeviceSelect = document.querySelector('#live-device');
+const liveFolderInput = document.querySelector('#live-folder');
+const liveSubjectInput = document.querySelector('#live-subject');
+const liveStartButton = document.querySelector('#live-start');
+const liveStopButton = document.querySelector('#live-stop');
+const liveResetButton = document.querySelector('#live-reset');
+const liveStreamStatus = document.querySelector('#live-stream-status');
+const liveStreamOutput = document.querySelector('#live-stream-output');
+const homePendingList = document.querySelector('#home-pending-list');
+const homePendingEmpty = document.querySelector('#home-pending-empty');
+const homePendingCount = document.querySelector('#home-pending-count');
+const homeFolderSummary = document.querySelector('#home-folder-summary');
+const homeRecentList = document.querySelector('#home-recent-list');
+const sectionToggles = document.querySelectorAll('[data-section-toggle]');
+const sectionPanels = document.querySelectorAll('[data-section]');
+const sectionJumpButtons = document.querySelectorAll('[data-section-jump]');
 
 const typingQueue = [];
 let typingInProgress = false;
+let cachedResults = [];
+let cachedFolderGroups = [];
+const folderFilters = {
+  category: 'all',
+  status: 'all',
+  topic: 'all',
+  search: '',
+};
+const DESTINATION_STORAGE_KEY = 'grabadora:last-destination-folder';
+const LAST_SECTION_STORAGE_KEY = 'grabadora:last-section';
+const LIVE_CHUNK_INTERVAL = 4000;
+
+let liveSessionId = null;
+let liveMediaStream = null;
+let liveRecorder = null;
+let liveChunkChain = Promise.resolve();
+let liveSessionActive = false;
+let destinationHintTimeout = null;
+
+const FOLDER_TAG_LABELS = {
+  temario: 'Temario',
+  tema: 'Tema',
+  practicas: 'Prácticas',
+  ejercicios: 'Ejercicios',
+  teoria: 'Teoría',
+};
+
+const SEVERITY_RANK = {
+  info: 0,
+  warning: 1,
+  error: 2,
+};
 
 function cancelTyping(container) {
   if (!container) return;
@@ -108,9 +167,135 @@ function computeResultsSignature(results) {
   return results
     .map((item) => {
       const updatedAt = item.updated_at || item.created_at || '';
-      return `${item.id}:${item.status}:${updatedAt}:${(item.text || '').length}`;
+      const latestEvent = Array.isArray(item.debug_events) && item.debug_events.length
+        ? item.debug_events[item.debug_events.length - 1]?.timestamp || item.debug_events.length
+        : 'no-events';
+      return `${item.id}:${item.status}:${updatedAt}:${(item.text || '').length}:${latestEvent}`;
     })
     .join('|');
+}
+
+function safeLocalStorageGet(key) {
+  try {
+    return window.localStorage?.getItem(key) ?? '';
+  } catch (error) {
+    console.warn('No se pudo leer localStorage:', error);
+    return '';
+  }
+}
+
+function safeLocalStorageSet(key, value) {
+  try {
+    if (value) {
+      window.localStorage?.setItem(key, value);
+    } else {
+      window.localStorage?.removeItem(key);
+    }
+  } catch (error) {
+    console.warn('No se pudo escribir en localStorage:', error);
+  }
+}
+
+function setActiveSection(targetSection, options = {}) {
+  if (!sectionPanels?.length) return;
+  const fallback = options.fallback || 'home';
+  const available = Array.from(sectionPanels, (panel) => panel.dataset.section).filter(Boolean);
+  const desired = available.includes(targetSection) ? targetSection : available.includes(fallback) ? fallback : available[0];
+  if (!desired) {
+    return;
+  }
+  sectionPanels.forEach((panel) => {
+    const active = panel.dataset.section === desired;
+    panel.classList.toggle('is-active', active);
+    panel.hidden = !active;
+  });
+  if (sectionToggles?.length) {
+    sectionToggles.forEach((toggle) => {
+      const active = toggle.dataset.sectionToggle === desired;
+      toggle.classList.toggle('is-active', active);
+      if (active) {
+        toggle.setAttribute('aria-current', 'page');
+      } else {
+        toggle.removeAttribute('aria-current');
+      }
+    });
+  }
+  if (!options?.skipPersist) {
+    safeLocalStorageSet(LAST_SECTION_STORAGE_KEY, desired);
+  }
+}
+
+function hideDestinationSavedHint() {
+  if (!destinationSavedHint) return;
+  destinationSavedHint.hidden = true;
+  if (destinationHintTimeout) {
+    window.clearTimeout(destinationHintTimeout);
+    destinationHintTimeout = null;
+  }
+}
+
+function persistDestinationFolder(value) {
+  const trimmed = (value || '').trim();
+  safeLocalStorageSet(DESTINATION_STORAGE_KEY, trimmed);
+  if (!destinationSavedHint) {
+    return;
+  }
+  if (!trimmed) {
+    hideDestinationSavedHint();
+    return;
+  }
+  destinationSavedHint.hidden = false;
+  if (destinationHintTimeout) {
+    window.clearTimeout(destinationHintTimeout);
+  }
+  destinationHintTimeout = window.setTimeout(() => {
+    hideDestinationSavedHint();
+  }, 1600);
+}
+
+function getStoredDestinationFolder() {
+  return safeLocalStorageGet(DESTINATION_STORAGE_KEY) || '';
+}
+
+function updateDestinationOptions(items) {
+  if (!destinationOptionsList) return;
+  const folders = new Set();
+  const stored = getStoredDestinationFolder();
+  if (stored) {
+    folders.add(stored);
+  }
+  if (Array.isArray(items)) {
+    for (const entry of items) {
+      const folderName = (entry?.output_folder || entry?.destination_folder || '').trim();
+      if (folderName) {
+        folders.add(folderName);
+      }
+    }
+  }
+  destinationOptionsList.innerHTML = '';
+  Array.from(folders)
+    .sort((a, b) => a.localeCompare(b, 'es'))
+    .forEach((folder) => {
+      const option = document.createElement('option');
+      option.value = folder;
+      destinationOptionsList.appendChild(option);
+    });
+}
+
+function handleDestinationInputChange(event) {
+  const value = event?.target?.value ?? destinationInput?.value ?? '';
+  persistDestinationFolder(value);
+  if (liveFolderInput && !liveFolderInput.value) {
+    liveFolderInput.value = value;
+  }
+}
+
+function handleLiveFolderChange(event) {
+  const value = event?.target?.value ?? liveFolderInput?.value ?? '';
+  persistDestinationFolder(value);
+  if (destinationInput && !destinationInput.value) {
+    destinationInput.value = value;
+  }
 }
 
 function splitIntoParagraphs(text) {
@@ -199,12 +384,12 @@ function ensureAutoScrollTracking(container) {
 ensureAutoScrollTracking(liveOutput);
 ensureAutoScrollTracking(studentPreviewBody);
 ensureAutoScrollTracking(modalText);
+ensureAutoScrollTracking(liveStreamOutput);
 
 function scrollContainerToEnd(container) {
   if (!container) return;
   ensureAutoScrollTracking(container);
   if (container.dataset.autoScroll === 'false') return;
-  if (!isContainerNearBottom(container)) return;
   const performScroll = () => {
     if (typeof container.scrollTo === 'function') {
       container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
@@ -301,6 +486,9 @@ function playTypewriterJob({ container, text, speedHint, placeholder, autoScroll
       container.dataset.fullText = sanitized;
       container.dataset.paragraphs = JSON.stringify(targetParagraphs);
       container.dataset.typing = 'false';
+      if (autoScroll) {
+        scrollContainerToEnd(container);
+      }
       resolve();
     };
 
@@ -468,8 +656,25 @@ function formatStatus(status) {
 }
 
 function formatDate(isoString) {
+  if (!isoString) {
+    return 'Sin fecha';
+  }
   const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return 'Sin fecha';
+  }
   return date.toLocaleString();
+}
+
+function formatShortDate(isoString) {
+  if (!isoString) {
+    return 'Sin fecha';
+  }
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return 'Sin fecha';
+  }
+  return date.toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' });
 }
 
 function formatBytes(bytes) {
@@ -585,6 +790,666 @@ function renderSpeakers(container, speakers) {
   container.hidden = safeSegments.length === 0;
 }
 
+function determineTranscriptionSeverity(item) {
+  if (!item) return 'info';
+  if (item.status === 'failed' || item.error_message) {
+    return 'error';
+  }
+  let severity = 'info';
+  const events = Array.isArray(item?.debug_events) ? item.debug_events : [];
+  for (const event of events) {
+    const level = (event.level || '').toLowerCase();
+    if (level === 'error') {
+      return 'error';
+    }
+    if (level === 'warning') {
+      severity = 'warning';
+    }
+  }
+  return severity;
+}
+
+function renderDebugEvents(container, events) {
+  if (!container) return;
+  const list = container.querySelector('ul');
+  if (!list) return;
+  const safeEvents = Array.isArray(events) ? events.slice(-6) : [];
+  list.innerHTML = '';
+  if (!safeEvents.length) {
+    container.hidden = true;
+    return;
+  }
+  for (const event of safeEvents) {
+    const item = document.createElement('li');
+    const level = (event.level || '').toLowerCase();
+    if (level) {
+      item.dataset.level = level;
+    }
+    const meta = document.createElement('span');
+    meta.className = 'debug-event__meta';
+    const stage = event.stage ? event.stage.toUpperCase() : 'SIN ETAPA';
+    meta.textContent = `${formatShortDate(event.timestamp)} • ${stage}`;
+    item.appendChild(meta);
+    const message = document.createElement('span');
+    message.className = 'debug-event__message';
+    message.textContent = event.message || 'Evento sin mensaje';
+    item.appendChild(message);
+    const extraEntries = event.extra && typeof event.extra === 'object'
+      ? Object.entries(event.extra)
+          .filter(([key, value]) => value !== null && value !== undefined && value !== '')
+          .map(([key, value]) => `${key}: ${value}`)
+      : [];
+    if (extraEntries.length) {
+      const extra = document.createElement('span');
+      extra.className = 'debug-event__extra';
+      extra.textContent = extraEntries.join(' • ');
+      item.appendChild(extra);
+    }
+    list.appendChild(item);
+  }
+  container.hidden = false;
+}
+
+function deriveFolderMetadata(item) {
+  const tags = new Set();
+  const topicNumbers = new Set();
+  const base = `${item?.output_folder ?? ''} ${item?.subject ?? ''} ${item?.original_filename ?? ''}`
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+  if (!base.trim()) {
+    return { tags, topicNumbers };
+  }
+  if (base.includes('temario')) {
+    tags.add('temario');
+  }
+  if (base.includes('practica') || base.includes('practicas')) {
+    tags.add('practicas');
+  }
+  if (base.includes('ejercicio') || base.includes('ejercicios')) {
+    tags.add('ejercicios');
+  }
+  if (base.includes('teoria')) {
+    tags.add('teoria');
+  }
+  const topicRegex = /tema[\s._-]*(\d+)/gi;
+  let matched = false;
+  let match;
+  while ((match = topicRegex.exec(base))) {
+    const value = Number.parseInt(match[1], 10);
+    if (Number.isFinite(value)) {
+      topicNumbers.add(value);
+      matched = true;
+    }
+  }
+  if (base.includes('tema') || matched) {
+    tags.add('tema');
+  }
+  return { tags, topicNumbers };
+}
+
+function buildFolderGroups(items) {
+  const results = Array.isArray(items) ? items : [];
+  const groups = new Map();
+  for (const item of results) {
+    const folderNameRaw = item?.output_folder || item?.destination_folder || 'Sin carpeta';
+    const folderName = (folderNameRaw || '').trim() || 'Sin carpeta';
+    const key = folderName.toLowerCase();
+    if (!groups.has(key)) {
+      groups.set(key, {
+        name: folderName,
+        items: [],
+        latestDate: null,
+        latestISO: null,
+        tags: new Set(),
+        topicNumbers: new Set(),
+        subjects: new Set(),
+        severity: 'info',
+      });
+    }
+    const group = groups.get(key);
+    group.items.push(item);
+    if (item?.subject) {
+      group.subjects.add(item.subject);
+    }
+    const isoDate = item?.updated_at || item?.created_at;
+    const timestamp = isoDate ? Date.parse(isoDate) : Number.NaN;
+    if (!Number.isNaN(timestamp)) {
+      if (!group.latestDate || timestamp > group.latestDate) {
+        group.latestDate = timestamp;
+        group.latestISO = isoDate;
+      }
+    }
+    const meta = deriveFolderMetadata(item);
+    meta.tags.forEach((tag) => group.tags.add(tag));
+    meta.topicNumbers.forEach((num) => group.topicNumbers.add(num));
+    const severity = determineTranscriptionSeverity(item);
+    if (SEVERITY_RANK[severity] > SEVERITY_RANK[group.severity]) {
+      group.severity = severity;
+    }
+  }
+  const ordered = Array.from(groups.values());
+  ordered.sort((a, b) => (b.latestDate || 0) - (a.latestDate || 0));
+  return ordered;
+}
+
+function updateFolderTopicOptions(groups) {
+  if (!folderTopicFilter) return;
+  const previous = folderTopicFilter.value || 'all';
+  const topics = new Set();
+  groups.forEach((group) => {
+    group.topicNumbers.forEach((num) => {
+      if (Number.isFinite(num)) {
+        topics.add(num);
+      }
+    });
+  });
+  const sortedTopics = Array.from(topics).sort((a, b) => a - b);
+  folderTopicFilter.innerHTML = '';
+  const defaultOption = document.createElement('option');
+  defaultOption.value = 'all';
+  defaultOption.textContent = 'Todos';
+  folderTopicFilter.appendChild(defaultOption);
+  sortedTopics.forEach((topic) => {
+    const option = document.createElement('option');
+    option.value = String(topic);
+    option.textContent = `Tema ${topic}`;
+    folderTopicFilter.appendChild(option);
+  });
+  if (previous !== 'all' && sortedTopics.includes(Number(previous))) {
+    folderTopicFilter.value = previous;
+    folderFilters.topic = previous;
+  } else {
+    folderTopicFilter.value = 'all';
+    folderFilters.topic = 'all';
+  }
+}
+
+function filterFolderGroups(groups) {
+  const searchTerm = folderFilters.search;
+  return groups.filter((group) => {
+    if (folderFilters.status !== 'all') {
+      const hasMatch = group.items.some((item) => matchesFolderStatus(item, folderFilters.status));
+      if (!hasMatch) {
+        return false;
+      }
+    }
+    if (folderFilters.category !== 'all') {
+      if (
+        folderFilters.category === 'tema' &&
+        !group.tags.has('tema') &&
+        group.topicNumbers.size === 0
+      ) {
+        return false;
+      }
+      if (
+        folderFilters.category !== 'tema' &&
+        !group.tags.has(folderFilters.category)
+      ) {
+        return false;
+      }
+    }
+    if (folderFilters.topic !== 'all') {
+      const topicNumber = Number(folderFilters.topic);
+      if (!group.topicNumbers.has(topicNumber)) {
+        return false;
+      }
+    }
+    if (searchTerm) {
+      const haystack = [
+        group.name,
+        ...group.subjects,
+        ...Array.from(group.tags).map((tag) => FOLDER_TAG_LABELS[tag] || tag),
+        ...Array.from(group.topicNumbers).map((num) => `tema ${num}`),
+      ]
+        .join(' ')
+        .toLowerCase();
+      if (!haystack.includes(searchTerm)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+function matchesFolderStatus(item, filterValue) {
+  if (!item) return false;
+  const status = (item.status || '').toLowerCase();
+  switch (filterValue) {
+    case 'in-progress':
+      return status === 'pending' || status === 'processing';
+    case 'completed':
+      return status === 'completed';
+    case 'failed':
+      return status === 'failed';
+    case 'premium':
+      return Boolean(item.premium_enabled);
+    default:
+      return true;
+  }
+}
+
+function createFolderGroupNode(group) {
+  const article = document.createElement('article');
+  article.className = 'folder-group';
+  article.dataset.severity = group.severity || 'info';
+  const header = document.createElement('div');
+  header.className = 'folder-group__header';
+  const title = document.createElement('h3');
+  title.textContent = group.name;
+  header.appendChild(title);
+  const count = document.createElement('span');
+  count.className = 'folder-group__count';
+  count.textContent = `${group.items.length} archivo${group.items.length === 1 ? '' : 's'}`;
+  header.appendChild(count);
+  article.appendChild(header);
+
+  const meta = document.createElement('p');
+  meta.className = 'folder-group__meta';
+  const subjectsLabel = group.subjects.size
+    ? ` • Materias: ${Array.from(group.subjects).join(', ')}`
+    : '';
+  meta.textContent = `Última actualización: ${formatShortDate(group.latestISO)}${subjectsLabel}`;
+  article.appendChild(meta);
+
+  const tagLabels = [
+    ...Array.from(group.tags).map((tag) => FOLDER_TAG_LABELS[tag] || tag),
+    ...Array.from(group.topicNumbers)
+      .sort((a, b) => a - b)
+      .map((num) => `Tema ${num}`),
+  ];
+  if (tagLabels.length) {
+    const tagList = document.createElement('div');
+    tagList.className = 'folder-group__tags';
+    tagLabels.forEach((label) => {
+      const badge = document.createElement('span');
+      badge.className = 'folder-group__tag';
+      badge.textContent = label;
+      tagList.appendChild(badge);
+    });
+    article.appendChild(tagList);
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'folder-group__list';
+  const sortedItems = [...group.items].sort((a, b) => {
+    const aDate = Date.parse(a?.updated_at || a?.created_at || 0) || 0;
+    const bDate = Date.parse(b?.updated_at || b?.created_at || 0) || 0;
+    return bDate - aDate;
+  });
+  sortedItems.slice(0, 4).forEach((item) => {
+    const listItem = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'folder-group__item';
+    button.setAttribute('data-folder-transcription', item.id);
+
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'folder-group__item-title';
+    titleSpan.textContent = item.original_filename;
+    button.appendChild(titleSpan);
+
+    const metaRow = document.createElement('div');
+    metaRow.className = 'folder-group__item-meta';
+    const dateInfo = document.createElement('span');
+    dateInfo.textContent = formatShortDate(item.updated_at || item.created_at);
+    metaRow.appendChild(dateInfo);
+
+    const status = document.createElement('span');
+    status.className = 'folder-group__status';
+    status.dataset.status = item.status;
+    status.textContent = formatStatus(item.status);
+    metaRow.appendChild(status);
+
+    if (item.model_size) {
+      const modelInfo = document.createElement('span');
+      modelInfo.textContent = item.model_size;
+      metaRow.appendChild(modelInfo);
+    }
+
+    button.appendChild(metaRow);
+
+    const severity = determineTranscriptionSeverity(item);
+    if (severity !== 'info') {
+      const severityBadge = document.createElement('span');
+      severityBadge.className = 'folder-group__tag';
+      severityBadge.textContent = severity === 'warning' ? 'Advertencia' : 'Error';
+      button.appendChild(severityBadge);
+    }
+
+    listItem.appendChild(button);
+    list.appendChild(listItem);
+  });
+  article.appendChild(list);
+
+  if (group.items.length > 4) {
+    const extra = document.createElement('p');
+    extra.className = 'folder-group__meta';
+    extra.textContent = `… y ${group.items.length - 4} elemento(s) más en esta carpeta.`;
+    article.appendChild(extra);
+  }
+
+  return article;
+}
+
+function renderHomeFolderSummary(groups) {
+  if (!homeFolderSummary) return;
+  homeFolderSummary.innerHTML = '';
+  const summary = Array.isArray(groups) ? groups.slice(0, 4) : [];
+  if (!summary.length) {
+    const empty = document.createElement('p');
+    empty.className = 'home-folder-summary__empty';
+    empty.textContent = 'Sube tu primer archivo para crear una carpeta y verla aquí.';
+    homeFolderSummary.appendChild(empty);
+    return;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'home-folder-summary__list';
+
+  summary.forEach((group) => {
+    const item = document.createElement('li');
+    item.className = 'home-folder-summary__item';
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'home-folder-summary__button';
+    button.setAttribute('data-folder-jump', group.name);
+
+    const title = document.createElement('span');
+    title.className = 'home-folder-summary__name';
+    title.textContent = group.name;
+    button.appendChild(title);
+
+    const itemsCount = Array.isArray(group.items) ? group.items.length : 0;
+    const countLabel = itemsCount === 1 ? '1 archivo' : `${itemsCount} archivos`;
+    const updatedLabel = group.latestISO ? formatDate(group.latestISO) : 'Sin fecha';
+    const meta = document.createElement('span');
+    meta.className = 'home-folder-summary__meta';
+    meta.textContent = `${countLabel} • ${updatedLabel}`;
+    button.appendChild(meta);
+
+    const tags = Array.from(group.tags ?? []).map((tag) => FOLDER_TAG_LABELS[tag] ?? tag);
+    if (tags.length) {
+      const tagsEl = document.createElement('span');
+      tagsEl.className = 'home-folder-summary__tags';
+      tagsEl.textContent = tags.join(' · ');
+      button.appendChild(tagsEl);
+    }
+
+    const subjects = Array.from(group.subjects ?? []);
+    if (subjects.length) {
+      const subjectsEl = document.createElement('span');
+      subjectsEl.className = 'home-folder-summary__subjects';
+      const label = subjects.slice(0, 2).join(' • ');
+      subjectsEl.textContent = label;
+      button.appendChild(subjectsEl);
+    }
+
+    if (group.severity && group.severity !== 'info') {
+      const badge = document.createElement('span');
+      badge.className = `home-folder-summary__badge is-${group.severity}`;
+      badge.textContent = group.severity === 'warning' ? 'Advertencias' : 'Error';
+      button.appendChild(badge);
+    }
+
+    item.appendChild(button);
+    list.appendChild(item);
+  });
+
+  homeFolderSummary.appendChild(list);
+}
+
+function applyFolderFilters() {
+  if (!folderGroupsContainer) return;
+  folderGroupsContainer.innerHTML = '';
+  if (!cachedFolderGroups.length) {
+    const empty = document.createElement('p');
+    empty.className = 'folder-group__empty';
+    empty.textContent = 'Todavía no hay carpetas registradas.';
+    folderGroupsContainer.appendChild(empty);
+    return;
+  }
+  const filtered = filterFolderGroups(cachedFolderGroups);
+  if (!filtered.length) {
+    const empty = document.createElement('p');
+    empty.className = 'folder-group__empty';
+    empty.textContent = 'No hay carpetas que coincidan con los filtros.';
+    folderGroupsContainer.appendChild(empty);
+    return;
+  }
+  for (const group of filtered) {
+    folderGroupsContainer.appendChild(createFolderGroupNode(group));
+  }
+}
+
+function renderFolderLibrary(items) {
+  if (!folderGroupsContainer) return;
+  cachedFolderGroups = buildFolderGroups(items);
+  updateFolderTopicOptions(cachedFolderGroups);
+  updateDestinationOptions(items);
+  renderHomeFolderSummary(cachedFolderGroups);
+  applyFolderFilters();
+}
+
+function updateSystemAlerts(items) {
+  if (!systemAlerts) return;
+  const results = Array.isArray(items) ? items : [];
+  const messages = new Set();
+  for (const item of results) {
+    const events = Array.isArray(item?.debug_events) ? item.debug_events : [];
+    for (const event of events) {
+      const message = (event.message || '').toLowerCase();
+      const stage = (event.stage || '').toLowerCase();
+      const extra = event?.extra || {};
+      if (!message) continue;
+      if (message.includes('whisperx no disponible')) {
+        messages.add(
+          'WhisperX requiere autenticación en HuggingFace. Configura la variable HUGGINGFACE_TOKEN para habilitar la diarización avanzada.',
+        );
+      }
+      if (message.includes('faster-whisper de respaldo')) {
+        messages.add(
+          'Se activó el modelo de respaldo en CPU. Verifica CUDA o tu GPU para mantener el rendimiento.',
+        );
+      }
+      if (stage === 'device.unavailable' || stage === 'device.fallback') {
+        messages.add(
+          'CUDA no está disponible en este momento. Comprueba que PyTorch detecte la GPU con `python -c "import torch; print(torch.cuda.is_available())"` y revisa tus drivers o WHISPER_FORCE_CUDA.',
+        );
+      }
+      if (stage === 'device.cuda-error') {
+        const details = String(extra?.error ?? '').slice(0, 160) || 'consulta los registros del servidor.';
+        messages.add(
+          `CUDA devolvió un error al inicializar (${details}). Verifica controladores, versión de PyTorch y reinicia el servicio si es necesario.`,
+        );
+      }
+      if (stage === 'load-model.failed') {
+        messages.add(
+          'Ninguna configuración de faster-whisper pudo cargarse. Limpia la caché de modelos en data/models o reinstala dependencias para restaurar el servicio.',
+        );
+      }
+    }
+  }
+  if (!messages.size) {
+    systemAlerts.hidden = true;
+    systemAlerts.innerHTML = '';
+    return;
+  }
+  systemAlerts.innerHTML = `
+    <p>Advertencias detectadas</p>
+    <ul>${Array.from(messages)
+      .map((text) => `<li>${text}</li>`)
+      .join('')}</ul>
+  `;
+  systemAlerts.hidden = false;
+}
+
+function renderHomePendingList(items) {
+  if (!homePendingList || !homePendingEmpty) return;
+  const pendingItems = (Array.isArray(items) ? items : []).filter(
+    (item) => item.status === 'processing',
+  );
+
+  if (homePendingCount) {
+    if (pendingItems.length) {
+      const label =
+        pendingItems.length === 1
+          ? '1 transcripción en curso'
+          : `${pendingItems.length} transcripciones en curso`;
+      homePendingCount.textContent = label;
+      homePendingCount.dataset.state = 'active';
+    } else {
+      homePendingCount.textContent = 'Sin tareas en curso';
+      homePendingCount.dataset.state = 'empty';
+    }
+  }
+
+  if (!pendingItems.length) {
+    homePendingList.hidden = true;
+    homePendingList.innerHTML = '';
+    homePendingEmpty.hidden = false;
+    return;
+  }
+
+  homePendingEmpty.hidden = true;
+  homePendingList.hidden = false;
+  homePendingList.innerHTML = '';
+
+  pendingItems.slice(0, 4).forEach((item) => {
+    const li = document.createElement('li');
+    li.className = 'home-pending-item';
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'home-pending-item__button';
+    button.setAttribute('data-pending-id', item.id);
+
+    const content = document.createElement('div');
+    content.className = 'home-pending-item__content';
+
+    const title = document.createElement('span');
+    title.className = 'home-pending-item__title';
+    title.textContent = item.original_filename || 'Transcripción en curso';
+    content.appendChild(title);
+
+    const folderLabel = item.output_folder || item.destination_folder || 'Sin carpeta';
+    const modelLabel = item.model_size || 'Modelo automático';
+    const deviceHint = (item.device_preference || '').trim().toUpperCase();
+    const deviceLabel = deviceHint || 'AUTO';
+    const contentMeta = document.createElement('span');
+    contentMeta.className = 'home-pending-item__meta';
+    contentMeta.textContent = `${folderLabel} • ${modelLabel} • ${deviceLabel}`;
+    content.appendChild(contentMeta);
+
+    button.appendChild(content);
+
+    const statusWrapper = document.createElement('div');
+    statusWrapper.className = 'home-pending-item__status';
+
+    const statusBadge = document.createElement('span');
+    statusBadge.className = 'home-pending-item__badge';
+    statusBadge.dataset.status = item.status;
+    statusBadge.textContent = formatStatus(item.status);
+    statusWrapper.appendChild(statusBadge);
+
+    const detailParts = [];
+    const runtimeSeconds = Number(item.runtime_seconds ?? 0);
+    if (runtimeSeconds > 0) {
+      detailParts.push(`Tiempo transcurrido: ${formatDuration(runtimeSeconds)}`);
+    }
+    const updatedLabel = formatShortDate(item.updated_at || item.created_at);
+    if (updatedLabel) {
+      detailParts.push(`Actualizado: ${updatedLabel}`);
+    }
+    const lastEvent = Array.isArray(item.debug_events)
+      ? item.debug_events[item.debug_events.length - 1]
+      : null;
+    const stageParts = (lastEvent?.stage || '')
+      .split(/[.\s_-]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1));
+    const stage = stageParts.join(' ');
+    if (stage) {
+      detailParts.push(stage);
+    }
+
+    if (detailParts.length) {
+      const details = document.createElement('span');
+      details.className = 'home-pending-item__details';
+      details.textContent = detailParts.join(' • ');
+      statusWrapper.appendChild(details);
+    }
+
+    button.appendChild(statusWrapper);
+    li.appendChild(button);
+    homePendingList.appendChild(li);
+  });
+}
+
+function renderHomeRecentList(items) {
+  if (!homeRecentList) return;
+  homeRecentList.innerHTML = '';
+  const results = Array.isArray(items) ? [...items] : [];
+  if (!results.length) {
+    const empty = document.createElement('p');
+    empty.className = 'home-recent-list__empty';
+    empty.textContent = 'Tus últimas transcripciones aparecerán aquí en cuanto subas audio.';
+    homeRecentList.appendChild(empty);
+    return;
+  }
+
+  results.sort((a, b) => {
+    const aDate = Date.parse(a?.updated_at || a?.created_at || 0) || 0;
+    const bDate = Date.parse(b?.updated_at || b?.created_at || 0) || 0;
+    return bDate - aDate;
+  });
+
+  const list = document.createElement('ul');
+  list.className = 'home-recent-list__list';
+
+  results.slice(0, 4).forEach((item) => {
+    const li = document.createElement('li');
+    li.className = 'home-recent-list__item';
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'home-recent-list__button';
+    button.setAttribute('data-recent-id', item.id);
+
+    const title = document.createElement('span');
+    title.className = 'home-recent-list__title';
+    title.textContent = item.original_filename;
+    button.appendChild(title);
+
+    const folderLabel = item.output_folder || item.destination_folder || 'Sin carpeta';
+    const folder = document.createElement('span');
+    folder.className = 'home-recent-list__folder';
+    folder.textContent = folderLabel;
+    button.appendChild(folder);
+
+    const meta = document.createElement('span');
+    meta.className = 'home-recent-list__meta';
+    const statusLabel = formatStatus(item.status);
+    const dateLabel = formatDate(item.updated_at || item.created_at);
+    meta.textContent = `${statusLabel} • ${dateLabel}`;
+    button.appendChild(meta);
+
+    const preview = (item.text || '').trim();
+    if (preview) {
+      const excerpt = document.createElement('span');
+      excerpt.className = 'home-recent-list__excerpt';
+      excerpt.textContent = preview.slice(0, 120);
+      button.appendChild(excerpt);
+    }
+
+    li.appendChild(button);
+    list.appendChild(li);
+  });
+
+  homeRecentList.appendChild(list);
+}
+
 function renderTranscriptions(items) {
   if (!transcriptionList) return;
   if (!template || !('content' in template)) {
@@ -593,6 +1458,10 @@ function renderTranscriptions(items) {
   }
   transcriptionList.innerHTML = '';
   const results = Array.isArray(items) ? items : [];
+  renderHomePendingList(results);
+  renderHomeRecentList(results);
+  renderFolderLibrary(results);
+  updateSystemAlerts(results);
   if (!results.length) {
     transcriptionList.innerHTML = '<p>No se encontraron transcripciones.</p>';
     return;
@@ -604,6 +1473,8 @@ function renderTranscriptions(items) {
     if (card) {
       card.style.setProperty('--card-delay', `${index * 60}ms`);
       card.dataset.status = item.status;
+      card.dataset.severity = determineTranscriptionSeverity(item);
+      card.dataset.transcriptionId = item.id;
     }
     node.querySelector('.transcription-title').textContent = item.original_filename;
     const statusBadge = node.querySelector('.status');
@@ -669,6 +1540,7 @@ function renderTranscriptions(items) {
     });
 
     renderSpeakers(node.querySelector('.speakers'), item.speakers);
+    renderDebugEvents(node.querySelector('.debug-events'), item.debug_events);
 
     transcriptionList.appendChild(node);
   }
@@ -696,6 +1568,7 @@ async function refreshTranscriptions(options = {}) {
 
       const data = await fetchJSON(url);
       const results = Array.isArray(data?.results) ? data.results : [];
+      cachedResults = results;
       const signature = computeResultsSignature(results);
       const changed = force || signature !== lastResultsSignature;
       lastResultsSignature = signature;
@@ -928,6 +1801,273 @@ function showStudentPlanInstructions(plan) {
   checkoutStatus.classList.add('success');
 }
 
+function supportsLiveStreaming() {
+  return Boolean(window.MediaRecorder && navigator.mediaDevices?.getUserMedia);
+}
+
+function setLiveStreamStatus(message, variant = 'info') {
+  if (!liveStreamStatus) return;
+  liveStreamStatus.textContent = message;
+  liveStreamStatus.dataset.state = variant === 'error' ? 'error' : 'info';
+}
+
+function resetLiveStreamUI(options = {}) {
+  if (!liveStreamOutput) return;
+  const placeholder = options.placeholder || 'Tu texto aparecerá aquí cuando empieces a hablar.';
+  resetStreamingContainer(liveStreamOutput, placeholder);
+  liveStreamOutput.dataset.stream = 'false';
+}
+
+function updateLiveControls() {
+  const supported = supportsLiveStreaming();
+  if (liveStartButton) {
+    liveStartButton.disabled = !supported || liveSessionActive;
+  }
+  if (liveStopButton) {
+    liveStopButton.disabled = !liveSessionActive;
+  }
+  if (liveResetButton) {
+    liveResetButton.disabled = !liveSessionId;
+  }
+  if (!supported) {
+    setLiveStreamStatus(
+      'Tu navegador no permite grabación en vivo. Usa Chrome, Edge o un navegador compatible para habilitarlo.',
+      'error',
+    );
+  }
+}
+
+function buildLiveSessionPayload() {
+  const language = liveLanguageSelect?.value?.trim();
+  const model = liveModelSelect?.value?.trim();
+  const device = liveDeviceSelect?.value?.trim();
+  return {
+    language: language || null,
+    model_size: model || null,
+    device_preference: device || null,
+  };
+}
+
+function applyLiveResult(result, options = {}) {
+  if (!liveStreamOutput) return;
+  const final = options.final === true;
+  const item = {
+    text: result?.text ?? '',
+    status: final ? 'completed' : 'processing',
+    model_size: result?.model_size || liveModelSelect?.value || '',
+    device_preference: result?.device_preference || liveDeviceSelect?.value || '',
+    duration: result?.duration,
+    runtime_seconds: result?.runtime_seconds,
+  };
+  renderStreamingView(liveStreamOutput, item, {
+    placeholder: 'Esperando audio en vivo…',
+  });
+  liveStreamOutput.dataset.stream = final ? 'false' : 'true';
+  if (final) {
+    scrollContainerToEnd(liveStreamOutput);
+  }
+}
+
+async function sendLiveChunk(blob) {
+  if (!liveSessionId || !blob || !blob.size) {
+    return;
+  }
+  const formData = new FormData();
+  const extension = blob.type && blob.type.includes('wav') ? '.wav' : '.webm';
+  formData.append('chunk', blob, `chunk-${Date.now()}${extension}`);
+  const response = await fetchJSON(`${API_BASE}/live/sessions/${liveSessionId}/chunk`, {
+    method: 'POST',
+    body: formData,
+  });
+  applyLiveResult(response);
+  const chunkCount = Number(response?.chunk_count ?? 0);
+  setLiveStreamStatus(
+    chunkCount > 0
+      ? `Transcribiendo en vivo (${chunkCount} fragmento${chunkCount === 1 ? '' : 's'})…`
+      : 'Transcribiendo en vivo…',
+  );
+}
+
+function enqueueLiveChunk(blob) {
+  if (!blob || !blob.size || !liveSessionId) return;
+  liveChunkChain = liveChunkChain
+    .then(() => sendLiveChunk(blob))
+    .catch((error) => {
+      console.error('Fallo al procesar fragmento en vivo:', error);
+      setLiveStreamStatus(`Error al procesar el audio: ${error.message}`, 'error');
+      liveSessionActive = false;
+      throw error;
+    });
+  return liveChunkChain;
+}
+
+async function startLiveSession() {
+  if (liveSessionActive || !supportsLiveStreaming()) {
+    updateLiveControls();
+    return;
+  }
+  try {
+    setLiveStreamStatus('Creando sesión en vivo…');
+    const payload = buildLiveSessionPayload();
+    const session = await fetchJSON(`${API_BASE}/live/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    liveSessionId = session?.session_id;
+    if (!liveSessionId) {
+      throw new Error('No se pudo iniciar la sesión en vivo');
+    }
+    const folder = liveFolderInput?.value?.trim();
+    if (folder) {
+      persistDestinationFolder(folder);
+    }
+    liveSessionActive = true;
+    liveChunkChain = Promise.resolve();
+    liveMediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const preferredMime =
+      typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+        ? 'audio/webm;codecs=opus'
+        : undefined;
+    liveRecorder = preferredMime
+      ? new MediaRecorder(liveMediaStream, { mimeType: preferredMime })
+      : new MediaRecorder(liveMediaStream);
+    liveRecorder.addEventListener('dataavailable', (event) => {
+      if (event.data && event.data.size) {
+        enqueueLiveChunk(event.data);
+      }
+    });
+    liveRecorder.addEventListener('stop', () => {
+      if (liveMediaStream) {
+        liveMediaStream.getTracks().forEach((track) => track.stop());
+        liveMediaStream = null;
+      }
+    });
+    liveRecorder.addEventListener('error', (event) => {
+      const message = event?.error?.message || 'Error desconocido del grabador';
+      setLiveStreamStatus(`La grabación en vivo falló: ${message}`, 'error');
+      liveSessionActive = false;
+      if (liveRecorder && liveRecorder.state !== 'inactive') {
+        liveRecorder.stop();
+      }
+    });
+    resetLiveStreamUI({ placeholder: 'Escuchando… di algo para comenzar.' });
+    liveRecorder.start(LIVE_CHUNK_INTERVAL);
+    setLiveStreamStatus('Grabando… habla cerca del micrófono para recibir texto.');
+  } catch (error) {
+    console.error('No se pudo iniciar la sesión en vivo:', error);
+    liveSessionId = null;
+    liveSessionActive = false;
+    setLiveStreamStatus(`No se pudo iniciar la sesión en vivo: ${error.message}`, 'error');
+    if (liveMediaStream) {
+      liveMediaStream.getTracks().forEach((track) => track.stop());
+      liveMediaStream = null;
+    }
+    if (liveRecorder && liveRecorder.state !== 'inactive') {
+      liveRecorder.stop();
+    }
+  } finally {
+    updateLiveControls();
+  }
+}
+
+async function finalizeLiveSession() {
+  if (!liveSessionId) return;
+  const folder = liveFolderInput?.value?.trim();
+  if (folder) {
+    persistDestinationFolder(folder);
+  }
+  try {
+    const payload = {
+      destination_folder: folder || getStoredDestinationFolder() || undefined,
+      subject: liveSubjectInput?.value?.trim() || undefined,
+      language: liveLanguageSelect?.value?.trim() || undefined,
+      model_size: liveModelSelect?.value?.trim() || undefined,
+      device_preference: liveDeviceSelect?.value?.trim() || undefined,
+    };
+    const result = await fetchJSON(`${API_BASE}/live/sessions/${liveSessionId}/finalize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    applyLiveResult(result, { final: true });
+    setLiveStreamStatus('Sesión guardada correctamente.');
+    liveSessionId = null;
+    liveSessionActive = false;
+    liveChunkChain = Promise.resolve();
+    liveRecorder = null;
+    if (liveSubjectInput) {
+      liveSubjectInput.value = '';
+    }
+    await refreshTranscriptions({ force: true });
+  } catch (error) {
+    console.error('No se pudo finalizar la sesión en vivo:', error);
+    setLiveStreamStatus(`No se pudo guardar la sesión: ${error.message}`, 'error');
+    liveSessionActive = false;
+    throw error;
+  } finally {
+    updateLiveControls();
+  }
+}
+
+async function stopLiveSession() {
+  if (!liveSessionId) {
+    return;
+  }
+  setLiveStreamStatus('Deteniendo y guardando la sesión en vivo…');
+  if (liveRecorder && liveRecorder.state !== 'inactive') {
+    liveRecorder.stop();
+  }
+  if (liveMediaStream) {
+    liveMediaStream.getTracks().forEach((track) => track.stop());
+    liveMediaStream = null;
+  }
+  try {
+    await liveChunkChain.catch(() => {});
+    await finalizeLiveSession();
+  } catch (error) {
+    // El mensaje ya se registró en finalizeLiveSession
+  } finally {
+    updateLiveControls();
+  }
+}
+
+async function discardLiveSession() {
+  if (!liveSessionId) {
+    resetLiveStreamUI();
+    setLiveStreamStatus('Sesión descartada. Lista para empezar de nuevo.');
+    updateLiveControls();
+    return;
+  }
+  if (liveRecorder && liveRecorder.state !== 'inactive') {
+    liveRecorder.stop();
+  }
+  if (liveMediaStream) {
+    liveMediaStream.getTracks().forEach((track) => track.stop());
+    liveMediaStream = null;
+  }
+  try {
+    await liveChunkChain.catch(() => {});
+  } catch (error) {
+    console.warn('Error al esperar la cola de fragmentos en vivo:', error);
+  }
+  try {
+    await fetchJSON(`${API_BASE}/live/sessions/${liveSessionId}`, {
+      method: 'DELETE',
+    });
+  } catch (error) {
+    console.warn('No se pudo descartar la sesión en vivo en el servidor:', error);
+  } finally {
+    liveSessionId = null;
+    liveSessionActive = false;
+    liveChunkChain = Promise.resolve();
+    liveRecorder = null;
+    resetLiveStreamUI();
+    setLiveStreamStatus('Sesión descartada. Lista para empezar de nuevo.');
+    updateLiveControls();
+  }
+}
+
 async function createCheckout(planSlug) {
   if (!selectedTranscriptionId) {
     checkoutStatus.textContent = 'Selecciona primero una transcripción en la lista.';
@@ -1011,15 +2151,26 @@ uploadForm?.addEventListener('submit', async (event) => {
     const queuedCount = Array.isArray(response?.items) ? response.items.length : 1;
     uploadStatus.textContent = `${queuedCount} archivo(s) en cola. Procesando transcripciones...`;
     uploadStatus.classList.remove('error');
+    persistDestinationFolder(destinationFolder);
+    const preservedModel = modelSelect?.value;
+    const preservedDevice = deviceSelect?.value;
+    const preservedLanguage = languageSelect?.value;
     uploadForm.reset();
-    if (modelSelect && modelSelect.dataset.default) {
-      modelSelect.value = modelSelect.dataset.default;
+    if (modelSelect) {
+      modelSelect.value = preservedModel || modelSelect.dataset.default || modelSelect.value;
     }
-    if (deviceSelect && deviceSelect.dataset.default) {
-      deviceSelect.value = deviceSelect.dataset.default;
+    if (deviceSelect) {
+      deviceSelect.value = preservedDevice || deviceSelect.dataset.default || deviceSelect.value;
     }
     if (languageSelect) {
-      languageSelect.value = languageSelect.querySelector('option[selected]')?.value ?? '';
+      const fallbackLanguage = languageSelect.querySelector('option[selected]')?.value ?? '';
+      languageSelect.value = preservedLanguage || fallbackLanguage;
+    }
+    if (destinationInput) {
+      destinationInput.value = destinationFolder;
+    }
+    if (liveFolderInput && !liveFolderInput.value) {
+      liveFolderInput.value = destinationFolder;
     }
     updateFilePreview();
     await refreshTranscriptions({ force: true });
@@ -1036,10 +2187,57 @@ fileTrigger?.addEventListener('click', (event) => {
 });
 
 fileInput?.addEventListener('change', updateFilePreview);
+const lastDestinationFolder = getStoredDestinationFolder();
+if (lastDestinationFolder) {
+  if (destinationInput) {
+    destinationInput.value = lastDestinationFolder;
+  }
+  if (liveFolderInput && !liveFolderInput.value) {
+    liveFolderInput.value = lastDestinationFolder;
+  }
+}
+updateDestinationOptions([]);
+resetLiveStreamUI();
+setLiveStreamStatus('Tu texto aparecerá aquí cuando empieces a hablar.');
+updateLiveControls();
+liveStartButton?.addEventListener('click', startLiveSession);
+liveStopButton?.addEventListener('click', stopLiveSession);
+liveResetButton?.addEventListener('click', discardLiveSession);
+destinationInput?.addEventListener('change', handleDestinationInputChange);
+destinationInput?.addEventListener('blur', handleDestinationInputChange);
+liveFolderInput?.addEventListener('change', handleLiveFolderChange);
+liveFolderInput?.addEventListener('blur', handleLiveFolderChange);
 searchInput?.addEventListener('input', handleSearch);
 filterPremium?.addEventListener('change', (event) => {
   premiumOnly = event.target.checked;
   refreshTranscriptions({ force: true });
+});
+folderCategoryFilter?.addEventListener('change', (event) => {
+  folderFilters.category = event.target.value;
+  applyFolderFilters();
+});
+folderStatusFilter?.addEventListener('change', (event) => {
+  folderFilters.status = event.target.value;
+  applyFolderFilters();
+});
+folderTopicFilter?.addEventListener('change', (event) => {
+  folderFilters.topic = event.target.value;
+  applyFolderFilters();
+});
+folderSearchInput?.addEventListener('input', (event) => {
+  folderFilters.search = event.target.value.trim().toLowerCase();
+  applyFolderFilters();
+});
+folderResetButton?.addEventListener('click', () => {
+  folderFilters.category = 'all';
+  folderFilters.status = 'all';
+  folderFilters.topic = 'all';
+  folderFilters.search = '';
+  if (folderCategoryFilter) folderCategoryFilter.value = 'all';
+  if (folderStatusFilter) folderStatusFilter.value = 'all';
+  if (folderTopicFilter) folderTopicFilter.value = 'all';
+  if (folderSearchInput) folderSearchInput.value = '';
+  applyFolderFilters();
 });
 modalClose?.addEventListener('click', () => (modal.hidden = true));
 modal?.addEventListener('click', (event) => {
@@ -1058,6 +2256,84 @@ plansContainer?.addEventListener('click', (event) => {
   }
   createCheckout(slug);
 });
+
+folderGroupsContainer?.addEventListener('click', (event) => {
+  const trigger = event.target.closest('[data-folder-transcription]');
+  if (!trigger) return;
+  const id = Number(trigger.getAttribute('data-folder-transcription'));
+  if (!Number.isFinite(id)) return;
+  selectedTranscriptionId = id;
+  if (liveOutput) {
+    liveOutput.dataset.autoScroll = 'true';
+  }
+  updateLivePreview(cachedResults);
+  scrollContainerToEnd(liveOutput);
+});
+
+homePendingList?.addEventListener('click', (event) => {
+  const button = event.target.closest('[data-pending-id]');
+  if (!button) return;
+  const id = Number(button.getAttribute('data-pending-id'));
+  if (!Number.isFinite(id)) return;
+  selectedTranscriptionId = id;
+  updateLivePreview(cachedResults);
+  openModal(id);
+});
+
+homeFolderSummary?.addEventListener('click', (event) => {
+  const button = event.target.closest('[data-folder-jump]');
+  if (!button) return;
+  const folder = button.getAttribute('data-folder-jump');
+  if (!folder) return;
+  folderFilters.search = folder.toLowerCase();
+  if (folderSearchInput) {
+    folderSearchInput.value = folder;
+  }
+  applyFolderFilters();
+  setActiveSection('library', { fallback: 'home' });
+  window.requestAnimationFrame(() => {
+    folderGroupsContainer?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+});
+
+homeRecentList?.addEventListener('click', (event) => {
+  const button = event.target.closest('[data-recent-id]');
+  if (!button) return;
+  const id = Number(button.getAttribute('data-recent-id'));
+  if (!Number.isFinite(id)) return;
+  selectedTranscriptionId = id;
+  updateLivePreview(cachedResults);
+  openModal(id);
+});
+
+renderHomePendingList([]);
+renderHomeFolderSummary([]);
+renderHomeRecentList([]);
+
+if (folderGroupsContainer) {
+  applyFolderFilters();
+}
+
+if (sectionToggles?.length) {
+  sectionToggles.forEach((button) => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.sectionToggle;
+      setActiveSection(target, { fallback: 'home' });
+    });
+  });
+}
+
+if (sectionJumpButtons?.length) {
+  sectionJumpButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.sectionJump;
+      setActiveSection(target, { fallback: 'home' });
+    });
+  });
+}
+
+const savedSection = safeLocalStorageGet(LAST_SECTION_STORAGE_KEY);
+setActiveSection(savedSection || 'home', { fallback: 'home', skipPersist: true });
 
 document.addEventListener('DOMContentLoaded', () => {
   resetCopyFeedback();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,11 +17,11 @@
         <span class="brand-mark" aria-hidden="true">🎙️</span>
         <span class="brand-name">Grabadora Pro</span>
       </div>
-      <nav class="app-nav" aria-label="Secciones">
-        <a href="#upload" class="nav-link">Subir</a>
-        <a href="#recientes" class="nav-link">Transcripciones</a>
-        <a href="#planes" class="nav-link">Beneficios</a>
-        <a href="#about" class="nav-link">Sobre mí</a>
+      <nav class="app-nav" aria-label="Navegación principal">
+        <button type="button" class="nav-link is-active" data-section-toggle="home" aria-current="page">Inicio</button>
+        <button type="button" class="nav-link" data-section-toggle="library">Biblioteca</button>
+        <button type="button" class="nav-link" data-section-toggle="live">En vivo</button>
+        <button type="button" class="nav-link" data-section-toggle="benefits">Beneficios</button>
       </nav>
       <button id="google-login" type="button" class="google-btn">
         <span class="icon">🔐</span>
@@ -29,225 +29,386 @@
       </button>
     </header>
 
-    <section class="hero" id="upload">
-      <div class="hero-content">
-        <h1>Transcripciones rápidas con IA premium</h1>
-        <p>
-          Procesa audio y video en paralelo, identifica ponentes con WhisperX y ofrece notas de valor a tus clientes en cuestión de minutos.
-        </p>
-        <div class="hero-tags">
-          <span>WhisperX + CUDA</span>
-          <span>Diarización avanzada</span>
-          <span>Pagos recurrentes</span>
-        </div>
-      </div>
-      <div class="hero-visual" aria-hidden="true">
-        <div class="wave"></div>
-        <div class="wave"></div>
-        <div class="wave"></div>
-      </div>
-    </section>
-
     <main class="layout">
-      <section class="card metrics-card" aria-label="Resumen de actividad">
-        <h2 class="visually-hidden">Resumen de actividad</h2>
-        <div class="metrics-grid">
-          <article class="metric">
-            <p class="metric-label">Transcripciones</p>
-            <p class="metric-value" data-metric="total">0</p>
-            <p class="metric-sub">Historial total en la plataforma</p>
-          </article>
-          <article class="metric">
-            <p class="metric-label">Completadas</p>
-            <p class="metric-value" data-metric="completed">0</p>
-            <p class="metric-sub">Listas para descargar</p>
-          </article>
-          <article class="metric">
-            <p class="metric-label">En cola</p>
-            <p class="metric-value" data-metric="processing">0</p>
-            <p class="metric-sub">Procesándose en tiempo real</p>
-          </article>
-          <article class="metric">
-            <p class="metric-label">Premium &nbsp;|&nbsp; Minutos</p>
-            <p class="metric-value metric-stack">
-              <span data-metric="premium">0</span>
-              <span data-metric="minutes">0 min</span>
+      <section class="main-section is-active" data-section="home">
+        <section class="hero" id="upload">
+          <div class="hero-content">
+            <h1>Transcribe sin complicaciones</h1>
+            <p>
+              Sube tus clases, prácticas o notas de voz y sigue la transcripción en vivo mientras trabajamos por ti.
             </p>
-            <p class="metric-sub">Clientes con IA + duración agregada</p>
-          </article>
+            <div class="hero-tags">
+              <span>WhisperX optimizado</span>
+              <span>Carpetas automáticas</span>
+              <span>Streaming en tiempo real</span>
+            </div>
+          </div>
+          <div class="hero-visual" aria-hidden="true">
+            <div class="wave"></div>
+            <div class="wave"></div>
+            <div class="wave"></div>
+          </div>
+        </section>
+
+        <div class="home-dashboard">
+          <section class="card home-pending-card" aria-labelledby="home-pending-heading">
+            <div class="card-header">
+              <h2 id="home-pending-heading">Tareas pendientes</h2>
+              <p class="section-lead">Controla las transcripciones en curso y salta a la biblioteca cuando necesites más detalle.</p>
+            </div>
+            <div class="home-pending-meta">
+              <span id="home-pending-count" class="badge badge-soft" aria-live="polite">Sin tareas en curso</span>
+              <button type="button" class="ghost" data-section-jump="library">Abrir cola completa</button>
+            </div>
+            <p id="home-pending-empty" class="home-pending-empty">No tienes transcripciones procesándose ahora mismo.</p>
+            <ul id="home-pending-list" class="home-pending-list" hidden aria-live="polite"></ul>
+          </section>
+
+          <div class="home-columns">
+            <section class="card upload-card" aria-labelledby="upload-heading">
+              <div class="card-header">
+                <h2 id="upload-heading">Transcripción rápida</h2>
+                <p class="section-lead">
+                  Elige tus archivos, selecciona la carpeta de destino y deja que la app haga el resto.
+                </p>
+              </div>
+              <form id="upload-form" class="upload-form">
+                <div class="file-picker">
+                  <input
+                    id="audio-file"
+                    type="file"
+                    accept="audio/*,video/*"
+                    multiple
+                    hidden
+                  />
+                  <label for="audio-file" class="file-trigger" role="button" tabindex="0">
+                    <span class="file-trigger__pulse"></span>
+                    <span class="file-trigger__pulse"></span>
+                    <span class="icon">📁</span>
+                    <span class="text">Elegir archivos</span>
+                  </label>
+                  <p class="hint">Formatos compatibles: mp3, wav, m4a, mp4, webm y más.</p>
+                </div>
+                <div id="file-preview" class="file-preview" hidden></div>
+                <div id="file-error" class="form-error" hidden></div>
+
+                <div class="field">
+                  <label class="form-label" for="destination-folder">Carpeta destino</label>
+                  <input
+                    id="destination-folder"
+                    type="text"
+                    name="destination_folder"
+                    placeholder="Ej: clase-historia"
+                    list="destination-folder-options"
+                    required
+                  />
+                  <datalist id="destination-folder-options"></datalist>
+                </div>
+
+                <details class="advanced-options">
+                  <summary>Opciones avanzadas</summary>
+                  <div class="form-grid">
+                    <div class="field">
+                      <label class="form-label" for="language">Idioma preferido</label>
+                      <select id="language" name="language">
+                        <option value="">Detección automática</option>
+                        <option value="es" selected>Español</option>
+                        <option value="en">Inglés</option>
+                        <option value="fr">Francés</option>
+                      </select>
+                    </div>
+
+                    <div class="field">
+                      <label class="form-label" for="model-size">Modelo WhisperX</label>
+                      <select id="model-size" name="model_size" data-default="large-v3">
+                        <option value="large-v3" selected>large-v3 (máxima precisión)</option>
+                        <option value="large-v2">large-v2 (estable)</option>
+                        <option value="medium">medium (equilibrado)</option>
+                        <option value="small">small (más veloz)</option>
+                      </select>
+                    </div>
+
+                    <div class="field">
+                      <label class="form-label" for="device-preference">Dispositivo preferido</label>
+                      <select id="device-preference" name="device_preference" data-default="gpu">
+                        <option value="gpu" selected>GPU / CUDA (recomendado)</option>
+                        <option value="cpu">CPU</option>
+                      </select>
+                    </div>
+                  </div>
+                </details>
+
+                <div class="live-inline-hint" id="destination-saved-hint" hidden>
+                  <span class="icon">💾</span>
+                  <span>Guardando última carpeta usada…</span>
+                </div>
+
+                <button type="submit" class="primary upload-button">
+                  <span class="glow"></span>
+                  <span class="label">Subir y transcribir</span>
+                </button>
+              </form>
+              <div class="upload-feedback">
+                <div id="upload-progress" class="progress-track" hidden>
+                  <div class="progress-bar"></div>
+                </div>
+                <div id="upload-status" class="upload-status" aria-live="polite"></div>
+              </div>
+            </section>
+
+            <section class="card live-stream-card" aria-labelledby="live-stream-heading">
+              <div class="card-header">
+                <h2 id="live-stream-heading">Transcripción en línea</h2>
+                <p class="section-lead">Graba con tu micrófono, conserva el audio y obtén subtítulos mientras hablas.</p>
+              </div>
+
+              <div class="live-stream-wrapper">
+                <div class="live-stream-config">
+                  <div class="live-stream-controls">
+                    <div class="field">
+                      <label class="form-label" for="live-language">Idioma</label>
+                      <select id="live-language" name="live_language">
+                        <option value="">Detección automática</option>
+                        <option value="es" selected>Español</option>
+                        <option value="en">Inglés</option>
+                        <option value="fr">Francés</option>
+                      </select>
+                    </div>
+
+                    <div class="field">
+                      <label class="form-label" for="live-model">Modelo</label>
+                      <select id="live-model" name="live_model" data-default="large-v3">
+                        <option value="large-v3" selected>large-v3</option>
+                        <option value="large-v2">large-v2</option>
+                        <option value="medium">medium</option>
+                        <option value="small">small</option>
+                      </select>
+                    </div>
+
+                    <div class="field">
+                      <label class="form-label" for="live-device">Dispositivo</label>
+                      <select id="live-device" name="live_device" data-default="gpu">
+                        <option value="gpu" selected>GPU / CUDA</option>
+                        <option value="cpu">CPU</option>
+                      </select>
+                    </div>
+
+                    <div class="field">
+                      <label class="form-label" for="live-folder">Carpeta destino</label>
+                      <input
+                        id="live-folder"
+                        type="text"
+                        name="live_folder"
+                        placeholder="Ej: clases-en-vivo"
+                        list="destination-folder-options"
+                      />
+                    </div>
+
+                    <div class="field">
+                      <label class="form-label" for="live-subject">Temario / notas</label>
+                      <input
+                        id="live-subject"
+                        type="text"
+                        name="live_subject"
+                        placeholder="Tema, práctica, teoría…"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="live-stream-actions">
+                    <button type="button" id="live-start" class="primary">
+                      <span class="icon">🎙️</span>
+                      <span>Iniciar transmisión</span>
+                    </button>
+                    <button type="button" id="live-stop" class="secondary" disabled>
+                      <span class="icon">⏹</span>
+                      <span>Detener y guardar</span>
+                    </button>
+                    <button type="button" id="live-reset" class="ghost" disabled>
+                      <span class="icon">🧹</span>
+                      <span>Descartar sesión</span>
+                    </button>
+                  </div>
+                </div>
+
+                <div class="live-stream-session">
+                  <h3 class="live-panel-title">Sesión en curso</h3>
+                  <div class="live-stream-status" id="live-stream-status" role="status" aria-live="polite">
+                    Tu texto aparecerá aquí cuando empieces a hablar.
+                  </div>
+                  <div id="live-stream-output" class="live-stream-output" aria-live="polite"></div>
+                </div>
+              </div>
+
+              <div class="live-preview-panel">
+                <div class="live-preview-header">
+                  <h3 class="live-panel-title">Vista en vivo instantánea</h3>
+                  <p class="live-panel-lead">Selecciona una transcripción para seguir el texto conforme llega cada segmento con auto-scroll.</p>
+                </div>
+                <div id="live-output" class="live-output" aria-live="polite">
+                  Selecciona cualquier transcripción para previsualizarla aquí.
+                </div>
+              </div>
+            </section>
+          </div>
         </div>
       </section>
 
-      <section class="card span-2 upload-card" aria-labelledby="upload-heading">
-        <div class="card-header">
-          <h2 id="upload-heading">Subir nuevos audios</h2>
-          <p class="section-lead">Arrastra varios archivos o selecciónalos manualmente. Los procesamos en paralelo.</p>
-        </div>
-        <form id="upload-form" class="upload-form">
-          <div class="file-picker">
-            <input
-              id="audio-file"
-              type="file"
-              accept="audio/*,video/*"
-              multiple
-              hidden
-            />
-            <label for="audio-file" class="file-trigger" role="button" tabindex="0">
-              <span class="file-trigger__pulse"></span>
-              <span class="file-trigger__pulse"></span>
-              <span class="icon">📁</span>
-              <span class="text">Elegir archivos</span>
+      <section class="main-section" data-section="library" hidden>
+        <section class="card span-2 folders-card" id="folders" aria-labelledby="folders-heading">
+          <div class="card-header">
+            <h2 id="folders-heading">Biblioteca por carpetas</h2>
+            <p class="section-lead">Revisa tus carpetas ordenadas por fecha y filtra por tipo de contenido.</p>
+          </div>
+          <div id="system-alerts" class="system-alerts" hidden aria-live="polite"></div>
+          <div class="folders-controls">
+            <label class="control" for="folder-category">
+              <span>Etiqueta</span>
+              <select id="folder-category">
+                <option value="all">Todas</option>
+                <option value="temario">Temario</option>
+                <option value="tema">Tema</option>
+                <option value="practicas">Prácticas</option>
+                <option value="ejercicios">Ejercicios</option>
+                <option value="teoria">Teoría</option>
+              </select>
             </label>
-            <p class="hint">Formatos compatibles: mp3, wav, m4a, mp4, webm y más.</p>
-          </div>
-          <div id="file-preview" class="file-preview" hidden></div>
-          <div id="file-error" class="form-error" hidden></div>
-
-          <div class="form-grid">
-            <div class="field">
-              <label class="form-label" for="language">Idioma preferido</label>
-              <select id="language" name="language">
-                <option value="">Detección automática</option>
-                <option value="es" selected>Español</option>
-                <option value="en">Inglés</option>
-                <option value="fr">Francés</option>
+            <label class="control" for="folder-status">
+              <span>Estado</span>
+              <select id="folder-status">
+                <option value="all">Todos</option>
+                <option value="in-progress">En progreso</option>
+                <option value="completed">Completadas</option>
+                <option value="failed">Con error</option>
+                <option value="premium">Premium</option>
               </select>
-            </div>
-
-            <div class="field">
-              <label class="form-label" for="model-size">Modelo WhisperX</label>
-              <select id="model-size" name="model_size" data-default="large-v3">
-                <option value="large-v3" selected>large-v3 (máxima precisión)</option>
-                <option value="large-v2">large-v2 (estable)</option>
-                <option value="medium">medium (equilibrado)</option>
-                <option value="small">small (más veloz)</option>
+            </label>
+            <label class="control" for="folder-topic">
+              <span>Número de tema</span>
+              <select id="folder-topic">
+                <option value="all">Todos</option>
               </select>
-            </div>
-
-            <div class="field">
-              <label class="form-label" for="device-preference">Dispositivo preferido</label>
-              <select id="device-preference" name="device_preference" data-default="gpu">
-                <option value="gpu" selected>GPU / CUDA (recomendado)</option>
-                <option value="cpu">CPU</option>
-              </select>
-            </div>
-
-            <div class="field">
-              <label class="form-label" for="destination-folder">Carpeta destino (obligatoria)</label>
-              <input
-                id="destination-folder"
-                type="text"
-                name="destination_folder"
-                placeholder="Ej: clase-historia"
-                required
-              />
-              <p class="hint">La transcripción en TXT se guardará en esta carpeta dentro del directorio configurado.</p>
-            </div>
-
-            <div class="field">
-              <label class="form-label" for="destination-folder">Carpeta destino (obligatoria)</label>
-              <input
-                id="destination-folder"
-                type="text"
-                name="destination_folder"
-                placeholder="Ej: clase-historia"
-                required
-              />
-              <p class="hint">La transcripción en TXT se guardará en esta carpeta dentro del directorio configurado.</p>
-            </div>
-
+            </label>
+            <label class="control control--wide" for="folder-search">
+              <span>Buscar carpeta, asignatura o etiqueta</span>
+              <input id="folder-search" type="search" placeholder="Ej: historia, tema 3, teoría" />
+            </label>
+            <button id="folder-reset" type="button" class="ghost">Limpiar filtros</button>
           </div>
+          <div id="folder-groups" class="folder-groups" aria-live="polite"></div>
+        </section>
 
-          <button type="submit" class="primary upload-button">
-            <span class="glow"></span>
-            <span class="label">Subir y transcribir</span>
-          </button>
-        </form>
-        <div class="upload-feedback">
-          <div id="upload-progress" class="progress-track" hidden>
-            <div class="progress-bar"></div>
+        <section class="card metrics-card" aria-label="Resumen de actividad">
+          <h2 class="visually-hidden">Resumen de actividad</h2>
+          <div class="metrics-grid">
+            <article class="metric">
+              <p class="metric-label">Transcripciones</p>
+              <p class="metric-value" data-metric="total">0</p>
+              <p class="metric-sub">Historial total en la plataforma</p>
+            </article>
+            <article class="metric">
+              <p class="metric-label">Completadas</p>
+              <p class="metric-value" data-metric="completed">0</p>
+              <p class="metric-sub">Listas para descargar</p>
+            </article>
+            <article class="metric">
+              <p class="metric-label">En cola</p>
+              <p class="metric-value" data-metric="processing">0</p>
+              <p class="metric-sub">Procesándose en tiempo real</p>
+            </article>
+            <article class="metric">
+              <p class="metric-label">Premium &nbsp;|&nbsp; Minutos</p>
+              <p class="metric-value metric-stack">
+                <span data-metric="premium">0</span>
+                <span data-metric="minutes">0 min</span>
+              </p>
+              <p class="metric-sub">Clientes con IA + duración agregada</p>
+            </article>
           </div>
-          <div id="upload-status" class="upload-status" aria-live="polite"></div>
-        </div>
-      </section>
+        </section>
 
-      <section class="card span-2 live-card" aria-labelledby="live-heading">
-        <div class="card-header">
-          <h2 id="live-heading">Vista en vivo instantánea</h2>
-          <p class="section-lead">Selecciona una transcripción para seguir el texto conforme llega cada segmento, ordenado y sin retrasos artificiales.</p>
-        </div>
-        <div id="live-output" class="live-output" aria-live="polite">
-          Selecciona cualquier transcripción para previsualizarla aquí.
-        </div>
-      </section>
-
-      <section class="card span-2 student-card" id="student-web" aria-labelledby="student-heading">
-        <div class="card-header">
-          <h2 id="student-heading">Modo estudiante en web</h2>
-          <p class="section-lead">Observa cómo se ejecuta la edición ligera con anuncios y computación local pensada para campus.</p>
-        </div>
-        <div class="student-controls">
-          <button id="open-student-web" type="button" class="primary-alt">Abrir simulador independiente</button>
-          <label class="toggle" for="student-follow">
-            <input id="student-follow" type="checkbox" checked />
-            <span>Sincronizar con la transcripción activa</span>
-          </label>
-        </div>
-        <div id="student-web-preview" class="student-preview">
-          <div class="student-preview__header">
-            <span>Vista previa incrustada</span>
-            <span class="badge">Plan estudiante</span>
+        <section class="card" id="recientes">
+          <div class="list-header">
+            <h2>Transcripciones recientes</h2>
+            <input id="search" type="search" placeholder="Buscar por texto, asignatura o estado" />
           </div>
-          <div id="student-preview-body" class="student-preview__body" aria-live="polite">
-            <p class="placeholder">Se vinculará automáticamente a la transcripción que esté en proceso.</p>
+          <div class="filters">
+            <label><input type="checkbox" id="filter-premium" /> Solo premium</label>
           </div>
-        </div>
+          <div id="transcription-list" class="transcription-list"></div>
+        </section>
       </section>
+      <section class="main-section" data-section="live" hidden>
+        <section class="card span-2 live-info-card" aria-labelledby="live-info-heading">
+          <div class="card-header">
+            <h2 id="live-info-heading">Centro en vivo</h2>
+            <p class="section-lead">Inicia tus sesiones desde Inicio y consulta aquí recursos y diagnósticos adicionales.</p>
+          </div>
+          <ul class="live-info-list">
+            <li><strong>Transcripción en línea</strong> ahora vive en la pestaña Inicio para que grabes y transcribas sin cambiar de vista.</li>
+            <li>La <em>Vista en vivo instantánea</em> también está en Inicio y mantiene el auto-scroll activo mientras llegan nuevos bloques.</li>
+            <li>Si detectamos problemas con CUDA o el modelo, verás avisos en la Biblioteca con los pasos sugeridos para solucionarlo.</li>
+          </ul>
+        </section>
 
-      <section class="card" id="recientes">
-        <div class="list-header">
-          <h2>Transcripciones recientes</h2>
-          <input id="search" type="search" placeholder="Buscar por texto, asignatura o estado" />
-        </div>
-        <div class="filters">
-          <label><input type="checkbox" id="filter-premium" /> Solo premium</label>
-        </div>
-        <div id="transcription-list" class="transcription-list"></div>
+        <section class="card span-2 student-card" id="student-web" aria-labelledby="student-heading">
+          <div class="card-header">
+            <h2 id="student-heading">Modo estudiante en web</h2>
+            <p class="section-lead">Observa cómo se ejecuta la edición ligera con anuncios y computación local pensada para campus.</p>
+          </div>
+          <div class="student-controls">
+            <button id="open-student-web" type="button" class="primary-alt">Abrir simulador independiente</button>
+            <label class="toggle" for="student-follow">
+              <input id="student-follow" type="checkbox" checked />
+              <span>Sincronizar con la transcripción activa</span>
+            </label>
+          </div>
+          <div id="student-web-preview" class="student-preview">
+            <div class="student-preview__header">
+              <span>Vista previa incrustada</span>
+              <span class="badge">Plan estudiante</span>
+            </div>
+            <div id="student-preview-body" class="student-preview__body" aria-live="polite">
+              <p class="placeholder">Se vinculará automáticamente a la transcripción que esté en proceso.</p>
+            </div>
+          </div>
+        </section>
       </section>
+      <section class="main-section" data-section="benefits" hidden>
+        <section class="card" id="planes">
+          <div class="list-header">
+            <h2>Beneficios premium</h2>
+            <button id="refresh-plans" type="button" class="ghost">Actualizar</button>
+          </div>
+          <p class="section-lead">Desbloquea notas IA, resúmenes estructurados y recordatorios inteligentes en cada transcripción.</p>
+          <div id="plans" class="plans"></div>
+          <div id="checkout-status" class="checkout-status" aria-live="polite"></div>
+        </section>
 
-      <section class="card" id="planes">
-        <div class="list-header">
-          <h2>Beneficios premium</h2>
-          <button id="refresh-plans" type="button" class="ghost">Actualizar</button>
-        </div>
-        <p class="section-lead">Desbloquea notas IA, resúmenes estructurados y recordatorios inteligentes en cada transcripción.</p>
-        <div id="plans" class="plans"></div>
-        <div id="checkout-status" class="checkout-status" aria-live="polite"></div>
-      </section>
-
-      <section class="card span-2 about-card" id="about">
-        <div class="card-header">
-          <h2>Sobre mí</h2>
-          <p class="section-lead">Hola, soy FERIA. Construyo herramientas que convierten tus grabaciones en apuntes claros y accionables.</p>
-        </div>
-        <div class="about-grid">
-          <article>
-            <h3>Visión</h3>
-            <p>Facilitar que estudiantes y profesionales capturen ideas sin preocuparse por el teclado. La aplicación detecta ponentes, resume y prepara notas premium listas para compartir.</p>
-          </article>
-          <article>
-            <h3>Funcionalidades destacadas</h3>
-            <ul>
-              <li>Diarización por voz con WhisperX optimizado para GPU.</li>
-              <li>Notas premium generadas automáticamente en segundos.</li>
-              <li>Panel visual con métricas animadas y vista estilo ChatGPT.</li>
-            </ul>
-          </article>
-          <article>
-            <h3>Próximos pasos</h3>
-            <p>Integrar recordatorios inteligentes, exportación a Notion y compatibilidad con más idiomas. Tus sugerencias son bienvenidas.</p>
-          </article>
-        </div>
+        <section class="card span-2 about-card" id="about">
+          <div class="card-header">
+            <h2>Sobre mí</h2>
+            <p class="section-lead">Hola, soy FERIA. Construyo herramientas que convierten tus grabaciones en apuntes claros y accionables.</p>
+          </div>
+          <div class="about-grid">
+            <article>
+              <h3>Visión</h3>
+              <p>Facilitar que estudiantes y profesionales capturen ideas sin preocuparse por el teclado. La aplicación detecta ponentes, resume y prepara notas premium listas para compartir.</p>
+            </article>
+            <article>
+              <h3>Funcionalidades destacadas</h3>
+              <ul>
+                <li>Diarización por voz con WhisperX optimizado para GPU.</li>
+                <li>Notas premium generadas automáticamente en segundos.</li>
+                <li>Panel visual con métricas animadas y vista estilo ChatGPT.</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Próximos pasos</h3>
+              <p>Integrar recordatorios inteligentes, exportación a Notion y compatibilidad con más idiomas. Tus sugerencias son bienvenidas.</p>
+            </article>
+          </div>
+        </section>
       </section>
     </main>
 
@@ -269,11 +430,20 @@
         <div class="actions">
           <a class="download" href="#" target="_blank" rel="noopener">Descargar TXT</a>
           <button class="view">Ver detalles</button>
-          <button class="delete" data-id="">Eliminar</button>
-          <button class="checkout ghost" data-id="">Comprar plan</button>
+          <details class="more-actions">
+            <summary>Más opciones</summary>
+            <div class="more-actions__content">
+              <button class="delete" data-id="">Eliminar</button>
+              <button class="checkout ghost" data-id="">Activar premium</button>
+            </div>
+          </details>
         </div>
         <details class="speakers">
           <summary>Hablantes detectados</summary>
+          <ul></ul>
+        </details>
+        <details class="debug-events" hidden>
+          <summary>Eventos técnicos</summary>
           <ul></ul>
         </details>
       </article>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -176,18 +176,43 @@ html {
   flex-wrap: wrap;
 }
 
+.app-nav::-webkit-scrollbar {
+  height: 6px;
+}
+
+.app-nav::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+}
+
 .nav-link {
   color: #cbd5f5;
-  text-decoration: none;
   font-size: 0.95rem;
-  padding: 0.35rem 0.6rem;
+  padding: 0.4rem 0.85rem;
   border-radius: 999px;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.2;
 }
 
 .nav-link:hover {
   background: var(--accent-soft);
   color: #f8fafc;
+}
+
+.nav-link:focus-visible {
+  outline: 2px solid rgba(148, 163, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.nav-link.is-active,
+.nav-link[aria-current='page'] {
+  background: var(--accent);
+  color: #0b1120;
+  box-shadow: 0 12px 26px rgba(99, 102, 241, 0.35);
 }
 
 .google-btn {
@@ -208,6 +233,7 @@ html {
 @media (max-width: 960px) {
   .app-bar {
     justify-content: center;
+    flex-wrap: wrap;
   }
 
   .brand {
@@ -217,12 +243,13 @@ html {
 
   .app-nav {
     width: 100%;
-    justify-content: center;
-    order: 3;
+    justify-content: flex-start;
+    order: 2;
+    overflow-x: auto;
   }
 
   .google-btn {
-    order: 2;
+    order: 3;
     margin-left: auto;
     margin-right: auto;
   }
@@ -239,6 +266,7 @@ html {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 2.5rem;
   align-items: center;
+  grid-column: 1 / -1;
 }
 
 .hero-content {
@@ -310,6 +338,14 @@ html {
   display: grid;
   gap: 2rem;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.main-section {
+  display: none;
+}
+
+.main-section.is-active {
+  display: contents;
 }
 
 .metrics-card {
@@ -401,7 +437,12 @@ html {
     grid-column: span 1;
   }
   .app-nav {
-    display: none;
+    order: 2;
+    width: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding: 0.5rem 0 0;
+    gap: 0.75rem;
   }
 }
 
@@ -413,6 +454,296 @@ html {
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
   display: grid;
   gap: 1.25rem;
+}
+
+.home-dashboard {
+  display: grid;
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.home-columns {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 900px) {
+  .home-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .home-columns {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.6fr);
+  }
+}
+
+@media (min-width: 1440px) {
+  .card {
+    padding: 2rem;
+  }
+}
+
+.home-pending-card {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.home-pending-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.home-pending-empty {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px dashed rgba(99, 102, 241, 0.35);
+  border-radius: 16px;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.home-pending-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.home-pending-item__button {
+  width: 100%;
+  text-align: left;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.85rem 1.25rem;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  border: 1px solid rgba(99, 102, 241, 0.26);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.home-pending-item__button:hover,
+.home-pending-item__button:focus-visible {
+  border-color: rgba(129, 140, 248, 0.7);
+  box-shadow: 0 18px 38px rgba(99, 102, 241, 0.25);
+}
+
+.home-pending-item__content {
+  display: grid;
+  gap: 0.35rem;
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
+.home-pending-item__title {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: #e0e7ff;
+  word-break: break-word;
+}
+
+.home-pending-item__meta {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.home-pending-item__status {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 0;
+  flex: 1 1 200px;
+  color: rgba(226, 232, 255, 0.85);
+}
+
+.home-pending-item__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(129, 140, 248, 0.25);
+  color: #c7d2fe;
+}
+
+.home-pending-item__badge[data-status='processing'] {
+  background: rgba(34, 197, 94, 0.18);
+  color: #bbf7d0;
+}
+
+.home-pending-item__badge[data-status='failed'] {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+}
+
+.home-pending-item__details {
+  font-size: 0.82rem;
+  line-height: 1.35;
+  color: rgba(203, 213, 225, 0.9);
+}
+
+.card-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.home-folder-summary {
+  display: grid;
+  gap: 1rem;
+}
+
+.home-folder-summary__empty {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.home-folder-summary__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.home-folder-summary__button {
+  width: 100%;
+  text-align: left;
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(99, 102, 241, 0.24);
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.home-folder-summary__button:hover,
+.home-folder-summary__button:focus-visible {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.home-folder-summary__name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.home-folder-summary__meta {
+  color: #cbd5f5;
+  font-size: 0.85rem;
+}
+
+.home-folder-summary__tags,
+.home-folder-summary__subjects {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.home-folder-summary__badge {
+  justify-self: start;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(250, 204, 21, 0.14);
+  color: #facc15;
+}
+
+.home-folder-summary__badge.is-error {
+  background: rgba(248, 113, 113, 0.18);
+  color: #f87171;
+}
+
+.home-recent-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.home-recent-list__empty {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.home-recent-list__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.home-recent-list__button {
+  width: 100%;
+  text-align: left;
+  display: grid;
+  gap: 0.3rem;
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  background: rgba(15, 23, 42, 0.5);
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.home-recent-list__button:hover,
+.home-recent-list__button:focus-visible {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.home-recent-list__title {
+  font-weight: 600;
+}
+
+.home-recent-list__folder {
+  color: #cbd5f5;
+  font-size: 0.85rem;
+}
+
+.home-recent-list__meta {
+  color: #94a3b8;
+  font-size: 0.82rem;
+}
+
+.home-recent-list__excerpt {
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.live-info-card {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.live-info-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.75rem;
+  color: #cbd5f5;
+}
+
+.live-info-list strong {
+  color: #f8fafc;
+}
+
+.live-info-list em {
+  color: #f472b6;
 }
 
 .card-header {
@@ -429,6 +760,46 @@ html {
 .upload-form {
   display: grid;
   gap: 1.5rem;
+}
+
+.advanced-options {
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  padding: 0.9rem 1.1rem;
+  color: #cbd5f5;
+}
+
+.advanced-options summary {
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+}
+
+.advanced-options summary::before {
+  content: '⚙️';
+  font-size: 1rem;
+}
+
+.advanced-options summary::after {
+  content: '▾';
+  font-size: 0.9rem;
+  transition: transform 0.2s ease;
+}
+
+.advanced-options[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.advanced-options summary::-webkit-details-marker {
+  display: none;
+}
+
+.advanced-options .form-grid {
+  margin-top: 1rem;
 }
 
 .file-picker {
@@ -665,6 +1036,149 @@ select:focus {
   color: var(--danger);
 }
 
+.live-inline-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 255, 0.7);
+  margin: 0.3rem 0 0.4rem;
+}
+
+.live-inline-hint .icon {
+  font-size: 1rem;
+}
+
+.live-stream-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.live-stream-wrapper {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1200px) {
+  .live-stream-wrapper {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.live-stream-config {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.live-stream-session {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.live-preview-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.live-preview-header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.live-panel-title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.live-panel-lead {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.live-stream-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  align-items: end;
+}
+
+.live-stream-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.live-stream-actions .icon {
+  font-size: 1rem;
+}
+
+.live-stream-status {
+  font-size: 0.95rem;
+  color: rgba(203, 213, 255, 0.85);
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(99, 102, 241, 0.24);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+}
+
+.live-stream-status[data-state='error'] {
+  border-color: rgba(239, 68, 68, 0.55);
+  color: rgba(254, 202, 202, 0.95);
+}
+
+.live-stream-output {
+  min-height: 160px;
+  max-height: 360px;
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1rem 1.2rem;
+  line-height: 1.6;
+  font-size: 1rem;
+  font-family: "Spline Sans Mono", "JetBrains Mono", monospace;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  position: relative;
+}
+
+.live-stream-output[data-stream='true'] {
+  border-color: rgba(99, 102, 241, 0.55);
+  box-shadow: 0 16px 30px rgba(99, 102, 241, 0.18);
+}
+
+.live-stream-output p {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.42);
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  position: relative;
+}
+
+.live-stream-output p[data-typing='true']::after {
+  content: "";
+  position: absolute;
+  right: 0.85rem;
+  top: 50%;
+  width: 2px;
+  height: 1.35em;
+  background: var(--accent);
+  transform: translateY(-50%);
+  animation: typingCaret 0.8s steps(2, end) infinite;
+}
+
 .form-error {
   margin-top: -0.25rem;
   color: var(--danger);
@@ -819,6 +1333,230 @@ select:focus {
   margin-right: 0.5rem;
 }
 
+.folders-card {
+  position: relative;
+}
+
+.folders-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.folders-controls .control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 160px;
+}
+
+.folders-controls .control span {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.control--wide {
+  flex: 1 1 240px;
+}
+
+.folders-controls select,
+.folders-controls input {
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.65);
+  color: #f8fafc;
+  padding: 0.55rem 0.75rem;
+  min-height: 2.6rem;
+}
+
+.folders-controls button {
+  min-height: 2.6rem;
+}
+
+.system-alerts {
+  border: 1px solid rgba(250, 204, 21, 0.45);
+  background: rgba(250, 204, 21, 0.12);
+  color: #fde68a;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.system-alerts p {
+  margin: 0;
+  font-weight: 600;
+  color: #fbbf24;
+}
+
+.system-alerts ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #fde68a;
+}
+
+.system-alerts li {
+  margin-bottom: 0.25rem;
+}
+
+.system-alerts li:last-child {
+  margin-bottom: 0;
+}
+
+.folder-groups {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.folder-group {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.folder-group[data-severity='warning'] {
+  border-color: rgba(250, 204, 21, 0.45);
+  box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.2);
+}
+
+.folder-group[data-severity='error'] {
+  border-color: rgba(248, 113, 113, 0.6);
+  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.22);
+}
+
+.folder-group__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  justify-content: space-between;
+}
+
+.folder-group__header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.folder-group__count {
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+.folder-group__meta {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+}
+
+.folder-group__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.folder-group__tag {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  text-transform: uppercase;
+  color: #e0e7ff;
+}
+
+.folder-group__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.folder-group__item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.45rem;
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  background: rgba(8, 15, 32, 0.65);
+  padding: 0.75rem;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+  font: inherit;
+}
+
+.folder-group__item:hover,
+.folder-group__item:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(99, 102, 241, 0.6);
+  outline: none;
+}
+
+.folder-group__item-title {
+  font-weight: 600;
+}
+
+.folder-group__item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.folder-group__status {
+  font-size: 0.75rem;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+  border: 1px solid transparent;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.folder-group__status[data-status='completed'] {
+  color: #22d3ee;
+  border-color: rgba(34, 211, 238, 0.45);
+  background: rgba(14, 165, 233, 0.12);
+}
+
+.folder-group__status[data-status='processing'] {
+  color: #facc15;
+  border-color: rgba(250, 204, 21, 0.45);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.folder-group__status[data-status='failed'] {
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.folder-group__status[data-status='pending'],
+.folder-group__status:not([data-status]) {
+  color: #a855f7;
+  border-color: rgba(168, 85, 247, 0.45);
+  background: rgba(168, 85, 247, 0.12);
+}
+
+.folder-group__empty {
+  margin: 0;
+  color: #94a3b8;
+  font-style: italic;
+}
+
 .transcription-list {
   display: grid;
   gap: 1.25rem;
@@ -835,6 +1573,16 @@ select:focus {
   overflow: hidden;
   animation: cardLift 0.55s ease both;
   animation-delay: var(--card-delay, 0ms);
+}
+
+.transcription[data-severity='warning'] {
+  border-color: rgba(250, 204, 21, 0.45);
+  box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.2);
+}
+
+.transcription[data-severity='error'] {
+  border-color: rgba(248, 113, 113, 0.55);
+  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.22);
 }
 
 .transcription::after {
@@ -941,6 +1689,7 @@ select:focus {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .actions a,
@@ -950,6 +1699,56 @@ select:focus {
   color: inherit;
 }
 
+.more-actions {
+  display: inline-block;
+  position: relative;
+}
+
+.more-actions summary {
+  cursor: pointer;
+  list-style: none;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 0.45rem 0.9rem;
+  background: rgba(15, 23, 42, 0.65);
+  color: #cbd5f5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.more-actions summary::after {
+  content: '▾';
+  font-size: 0.9rem;
+  transition: transform 0.2s ease;
+}
+
+.more-actions[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.more-actions summary::-webkit-details-marker {
+  display: none;
+}
+
+.more-actions__content {
+  margin-top: 0.6rem;
+  display: grid;
+  gap: 0.5rem;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 0.75rem;
+  min-width: 220px;
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.45);
+}
+
+.more-actions__content button {
+  width: 100%;
+  justify-content: flex-start;
+}
+
 .actions .download.disabled {
   pointer-events: none;
   cursor: not-allowed;
@@ -957,6 +1756,73 @@ select:focus {
   background: rgba(15, 23, 42, 0.55);
   border-color: rgba(148, 163, 184, 0.4);
   color: #94a3b8;
+}
+
+.debug-events {
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  padding-top: 0.75rem;
+}
+
+.debug-events summary {
+  cursor: pointer;
+  color: #cbd5f5;
+  font-weight: 600;
+}
+
+.debug-events[open] summary {
+  color: #f8fafc;
+}
+
+.debug-events ul {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.debug-events li {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  font-size: 0.85rem;
+}
+
+.debug-events li[data-level='warning'] {
+  border-color: rgba(250, 204, 21, 0.45);
+  color: #fde68a;
+}
+
+.debug-events li[data-level='error'] {
+  border-color: rgba(248, 113, 113, 0.5);
+  color: #fecaca;
+}
+
+.debug-events li span {
+  display: block;
+}
+
+.debug-event__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: #94a3b8;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.debug-event__message {
+  color: #e2e8f0;
+}
+
+.debug-event__extra {
+  color: #94a3b8;
+  font-size: 0.78rem;
+  word-break: break-word;
 }
 
 button,
@@ -1019,6 +1885,24 @@ button:hover,
   font-size: 0.7rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
+}
+
+.badge-soft {
+  background: rgba(99, 102, 241, 0.2);
+  color: #c7d2fe;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+}
+
+.badge-soft[data-state='empty'] {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.28);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.badge-soft[data-state='active'] {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.32);
+  color: #bbf7d0;
 }
 
 .ghost.error {


### PR DESCRIPTION
## Summary
- reorganize the home tab to prioritize pending queue visibility alongside quick uploads and live streaming controls
- add a pending-transcriptions widget with status badges and integrate the instant live preview into the streaming card
- refresh the layout and styles to support the simplified dashboard grid and updated live panels

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e394b4553c832184646d96428e235c