### PR TITLE
Reorganiza Inicio con métricas visibles y controles en vivo

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -23,12 +23,18 @@ const languageSelect = document.querySelector('#language');
 const modelSelect = document.querySelector('#model-size');
 const deviceSelect = document.querySelector('#device-preference');
 const liveOutput = document.querySelector('#live-output');
+const homeLiveOutput = document.querySelector('#home-live-output');
+const livePreviewTargets = [liveOutput, homeLiveOutput].filter(Boolean);
 const copyTranscriptBtn = document.querySelector('#copy-transcript');
 const metricTotal = document.querySelector('[data-metric="total"]');
 const metricCompleted = document.querySelector('[data-metric="completed"]');
 const metricProcessing = document.querySelector('[data-metric="processing"]');
 const metricPremium = document.querySelector('[data-metric="premium"]');
 const metricMinutes = document.querySelector('[data-metric="minutes"]');
+const metricMode = document.querySelector('[data-metric="mode"]');
+const metricModel = document.querySelector('[data-metric="model"]');
+const metricTodayMinutes = document.querySelector('[data-metric="todayMinutes"]');
+const metricTodayCount = document.querySelector('[data-metric="todayCount"]');
 const uploadProgress = document.querySelector('#upload-progress');
 
 const MEDIA_PREFIXES = ['audio/', 'video/'];
@@ -65,6 +71,10 @@ const metricSnapshot = {
   processing: 0,
   premium: 0,
   minutes: 0,
+  todayMinutes: 0,
+  todayCount: 0,
+  mode: '',
+  model: '',
 };
 let uploadProgressTimer = null;
 let uploadProgressValue = 0;
@@ -90,6 +100,7 @@ const liveDeviceSelect = document.querySelector('#live-device');
 const liveFolderInput = document.querySelector('#live-folder');
 const liveSubjectInput = document.querySelector('#live-subject');
 const liveStartButton = document.querySelector('#live-start');
+const livePauseButton = document.querySelector('#live-pause');
 const liveStopButton = document.querySelector('#live-stop');
 const liveResetButton = document.querySelector('#live-reset');
 const liveStreamStatus = document.querySelector('#live-stream-status');
@@ -99,6 +110,10 @@ const homePendingEmpty = document.querySelector('#home-pending-empty');
 const homePendingCount = document.querySelector('#home-pending-count');
 const homeFolderSummary = document.querySelector('#home-folder-summary');
 const homeRecentList = document.querySelector('#home-recent-list');
+const homeLiveStatus = document.querySelector('#home-live-status');
+const homeLiveControls = document.querySelectorAll('[data-live-control]');
+const homeQuickFolderInput = document.querySelector('#home-folder-quick');
+const scrollTargetButtons = document.querySelectorAll('[data-scroll-to]');
 const sectionToggles = document.querySelectorAll('[data-section-toggle]');
 const sectionPanels = document.querySelectorAll('[data-section]');
 const sectionJumpButtons = document.querySelectorAll('[data-section-jump]');
@@ -122,6 +137,7 @@ let liveMediaStream = null;
 let liveRecorder = null;
 let liveChunkChain = Promise.resolve();
 let liveSessionActive = false;
+let liveSessionPaused = false;
 let destinationHintTimeout = null;
 
 const FOLDER_TAG_LABELS = {
@@ -237,6 +253,9 @@ function hideDestinationSavedHint() {
 function persistDestinationFolder(value) {
   const trimmed = (value || '').trim();
   safeLocalStorageSet(DESTINATION_STORAGE_KEY, trimmed);
+  if (homeQuickFolderInput) {
+    homeQuickFolderInput.value = trimmed;
+  }
   if (!destinationSavedHint) {
     return;
   }
@@ -296,6 +315,17 @@ function handleLiveFolderChange(event) {
   if (destinationInput && !destinationInput.value) {
     destinationInput.value = value;
   }
+}
+
+function handleHomeQuickFolderChange(event) {
+  const value = event?.target?.value ?? homeQuickFolderInput?.value ?? '';
+  if (destinationInput) {
+    destinationInput.value = value;
+  }
+  if (liveFolderInput) {
+    liveFolderInput.value = value;
+  }
+  persistDestinationFolder(value);
 }
 
 function splitIntoParagraphs(text) {
@@ -381,7 +411,7 @@ function ensureAutoScrollTracking(container) {
   updateAutoScrollFlag(container);
 }
 
-ensureAutoScrollTracking(liveOutput);
+livePreviewTargets.forEach((output) => ensureAutoScrollTracking(output));
 ensureAutoScrollTracking(studentPreviewBody);
 ensureAutoScrollTracking(modalText);
 ensureAutoScrollTracking(liveStreamOutput);
@@ -1405,49 +1435,58 @@ function renderHomeRecentList(items) {
     return bDate - aDate;
   });
 
-  const list = document.createElement('ul');
-  list.className = 'home-recent-list__list';
+  const table = document.createElement('table');
+  table.className = 'home-recent-table__table';
+  table.createTHead().innerHTML = `
+    <tr>
+      <th scope="col">Nombre</th>
+      <th scope="col">Estado</th>
+      <th scope="col">Duración</th>
+      <th scope="col">Actualizado</th>
+      <th scope="col">Carpeta</th>
+    </tr>
+  `;
 
-  results.slice(0, 4).forEach((item) => {
-    const li = document.createElement('li');
-    li.className = 'home-recent-list__item';
+  const tbody = table.createTBody();
+  results.slice(0, 5).forEach((item) => {
+    const row = document.createElement('tr');
+    row.dataset.recentId = item.id;
+    row.tabIndex = 0;
+    row.setAttribute('role', 'button');
+    row.setAttribute('aria-label', `Abrir ${item.original_filename}`);
 
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'home-recent-list__button';
-    button.setAttribute('data-recent-id', item.id);
+    const nameCell = document.createElement('td');
+    nameCell.textContent = item.original_filename;
+    row.appendChild(nameCell);
 
-    const title = document.createElement('span');
-    title.className = 'home-recent-list__title';
-    title.textContent = item.original_filename;
-    button.appendChild(title);
+    const statusCell = document.createElement('td');
+    statusCell.textContent = formatStatus(item.status);
+    statusCell.dataset.status = item.status;
+    row.appendChild(statusCell);
 
-    const folderLabel = item.output_folder || item.destination_folder || 'Sin carpeta';
-    const folder = document.createElement('span');
-    folder.className = 'home-recent-list__folder';
-    folder.textContent = folderLabel;
-    button.appendChild(folder);
+    const durationCell = document.createElement('td');
+    durationCell.textContent = formatDuration(Number(item.duration ?? 0));
+    row.appendChild(durationCell);
 
-    const meta = document.createElement('span');
-    meta.className = 'home-recent-list__meta';
-    const statusLabel = formatStatus(item.status);
-    const dateLabel = formatDate(item.updated_at || item.created_at);
-    meta.textContent = `${statusLabel} • ${dateLabel}`;
-    button.appendChild(meta);
+    const updatedCell = document.createElement('td');
+    updatedCell.textContent = formatDate(item.updated_at || item.created_at);
+    row.appendChild(updatedCell);
 
-    const preview = (item.text || '').trim();
-    if (preview) {
-      const excerpt = document.createElement('span');
-      excerpt.className = 'home-recent-list__excerpt';
-      excerpt.textContent = preview.slice(0, 120);
-      button.appendChild(excerpt);
-    }
+    const folderCell = document.createElement('td');
+    folderCell.textContent = item.output_folder || item.destination_folder || 'Sin carpeta';
+    row.appendChild(folderCell);
 
-    li.appendChild(button);
-    list.appendChild(li);
+    tbody.appendChild(row);
   });
 
-  homeRecentList.appendChild(list);
+  homeRecentList.appendChild(table);
+}
+
+function handleRecentSelection(id) {
+  if (!Number.isFinite(id)) return;
+  selectedTranscriptionId = id;
+  updateLivePreview(cachedResults);
+  openModal(id);
 }
 
 function renderTranscriptions(items) {
@@ -1806,13 +1845,20 @@ function supportsLiveStreaming() {
 }
 
 function setLiveStreamStatus(message, variant = 'info') {
-  if (!liveStreamStatus) return;
-  liveStreamStatus.textContent = message;
-  liveStreamStatus.dataset.state = variant === 'error' ? 'error' : 'info';
+  const state = variant === 'error' ? 'error' : 'info';
+  if (liveStreamStatus) {
+    liveStreamStatus.textContent = message;
+    liveStreamStatus.dataset.state = state;
+  }
+  if (homeLiveStatus) {
+    homeLiveStatus.textContent = message;
+    homeLiveStatus.dataset.state = state;
+  }
 }
 
 function resetLiveStreamUI(options = {}) {
   if (!liveStreamOutput) return;
+  liveSessionPaused = false;
   const placeholder = options.placeholder || 'Tu texto aparecerá aquí cuando empieces a hablar.';
   resetStreamingContainer(liveStreamOutput, placeholder);
   liveStreamOutput.dataset.stream = 'false';
@@ -1823,17 +1869,67 @@ function updateLiveControls() {
   if (liveStartButton) {
     liveStartButton.disabled = !supported || liveSessionActive;
   }
+  const paused = liveRecorder?.state === 'paused' || liveSessionPaused;
+  if (livePauseButton) {
+    livePauseButton.disabled = !liveSessionActive;
+    const label = livePauseButton.querySelector('span:last-child');
+    if (label) {
+      label.textContent = paused ? 'Reanudar' : 'Pausar';
+    }
+  }
   if (liveStopButton) {
-    liveStopButton.disabled = !liveSessionActive;
+    liveStopButton.disabled = !liveSessionId;
   }
   if (liveResetButton) {
     liveResetButton.disabled = !liveSessionId;
+  }
+  if (homeLiveControls?.length) {
+    homeLiveControls.forEach((button) => {
+      const action = button.dataset.liveControl;
+      const label = button.querySelector('span:last-child');
+      if (action === 'start') {
+        button.disabled = !supported || liveSessionActive;
+      } else if (action === 'pause') {
+        button.disabled = !liveSessionActive;
+        if (label) {
+          label.textContent = paused ? 'Reanudar' : 'Pausar';
+        }
+      } else if (action === 'finish') {
+        button.disabled = !liveSessionId;
+      }
+    });
   }
   if (!supported) {
     setLiveStreamStatus(
       'Tu navegador no permite grabación en vivo. Usa Chrome, Edge o un navegador compatible para habilitarlo.',
       'error',
     );
+  }
+}
+
+function toggleLivePause() {
+  if (!liveRecorder || !liveSessionActive) {
+    return;
+  }
+  if (typeof liveRecorder.pause !== 'function' || typeof liveRecorder.resume !== 'function') {
+    setLiveStreamStatus('Tu navegador no admite pausar la grabación en vivo.', 'error');
+    return;
+  }
+  try {
+    if (liveRecorder.state === 'paused') {
+      liveRecorder.resume();
+      liveSessionPaused = false;
+      setLiveStreamStatus('Grabación reanudada.');
+    } else if (liveRecorder.state === 'recording') {
+      liveRecorder.pause();
+      liveSessionPaused = true;
+      setLiveStreamStatus('Sesión en pausa. Reanuda cuando quieras.');
+    }
+  } catch (error) {
+    console.error('No se pudo alternar la pausa de la sesión en vivo:', error);
+    setLiveStreamStatus(`No se pudo pausar/reanudar: ${error.message}`, 'error');
+  } finally {
+    updateLiveControls();
   }
 }
 
@@ -1943,21 +2039,32 @@ async function startLiveSession() {
         liveMediaStream = null;
       }
     });
+    liveRecorder.addEventListener('pause', () => {
+      liveSessionPaused = true;
+      updateLiveControls();
+    });
+    liveRecorder.addEventListener('resume', () => {
+      liveSessionPaused = false;
+      updateLiveControls();
+    });
     liveRecorder.addEventListener('error', (event) => {
       const message = event?.error?.message || 'Error desconocido del grabador';
       setLiveStreamStatus(`La grabación en vivo falló: ${message}`, 'error');
       liveSessionActive = false;
+      liveSessionPaused = false;
       if (liveRecorder && liveRecorder.state !== 'inactive') {
         liveRecorder.stop();
       }
     });
     resetLiveStreamUI({ placeholder: 'Escuchando… di algo para comenzar.' });
+    liveSessionPaused = false;
     liveRecorder.start(LIVE_CHUNK_INTERVAL);
     setLiveStreamStatus('Grabando… habla cerca del micrófono para recibir texto.');
   } catch (error) {
     console.error('No se pudo iniciar la sesión en vivo:', error);
     liveSessionId = null;
     liveSessionActive = false;
+    liveSessionPaused = false;
     setLiveStreamStatus(`No se pudo iniciar la sesión en vivo: ${error.message}`, 'error');
     if (liveMediaStream) {
       liveMediaStream.getTracks().forEach((track) => track.stop());
@@ -1994,6 +2101,7 @@ async function finalizeLiveSession() {
     setLiveStreamStatus('Sesión guardada correctamente.');
     liveSessionId = null;
     liveSessionActive = false;
+    liveSessionPaused = false;
     liveChunkChain = Promise.resolve();
     liveRecorder = null;
     if (liveSubjectInput) {
@@ -2015,6 +2123,7 @@ async function stopLiveSession() {
     return;
   }
   setLiveStreamStatus('Deteniendo y guardando la sesión en vivo…');
+  liveSessionPaused = false;
   if (liveRecorder && liveRecorder.state !== 'inactive') {
     liveRecorder.stop();
   }
@@ -2039,6 +2148,7 @@ async function discardLiveSession() {
     updateLiveControls();
     return;
   }
+  liveSessionPaused = false;
   if (liveRecorder && liveRecorder.state !== 'inactive') {
     liveRecorder.stop();
   }
@@ -2196,17 +2306,47 @@ if (lastDestinationFolder) {
     liveFolderInput.value = lastDestinationFolder;
   }
 }
+if (homeQuickFolderInput) {
+  homeQuickFolderInput.value = lastDestinationFolder;
+}
 updateDestinationOptions([]);
 resetLiveStreamUI();
 setLiveStreamStatus('Tu texto aparecerá aquí cuando empieces a hablar.');
 updateLiveControls();
 liveStartButton?.addEventListener('click', startLiveSession);
+livePauseButton?.addEventListener('click', toggleLivePause);
 liveStopButton?.addEventListener('click', stopLiveSession);
 liveResetButton?.addEventListener('click', discardLiveSession);
 destinationInput?.addEventListener('change', handleDestinationInputChange);
 destinationInput?.addEventListener('blur', handleDestinationInputChange);
 liveFolderInput?.addEventListener('change', handleLiveFolderChange);
 liveFolderInput?.addEventListener('blur', handleLiveFolderChange);
+homeQuickFolderInput?.addEventListener('change', handleHomeQuickFolderChange);
+homeQuickFolderInput?.addEventListener('blur', handleHomeQuickFolderChange);
+if (homeLiveControls?.length) {
+  homeLiveControls.forEach((button) => {
+    const action = button.dataset.liveControl;
+    if (action === 'start') {
+      button.addEventListener('click', startLiveSession);
+    } else if (action === 'pause') {
+      button.addEventListener('click', toggleLivePause);
+    } else if (action === 'finish') {
+      button.addEventListener('click', () => {
+        stopLiveSession();
+      });
+    }
+  });
+}
+scrollTargetButtons?.forEach((button) => {
+  button.addEventListener('click', () => {
+    const selector = button.dataset.scrollTo;
+    if (!selector) return;
+    const target = document.querySelector(selector);
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  });
+});
 searchInput?.addEventListener('input', handleSearch);
 filterPremium?.addEventListener('change', (event) => {
   premiumOnly = event.target.checked;
@@ -2263,11 +2403,13 @@ folderGroupsContainer?.addEventListener('click', (event) => {
   const id = Number(trigger.getAttribute('data-folder-transcription'));
   if (!Number.isFinite(id)) return;
   selectedTranscriptionId = id;
-  if (liveOutput) {
-    liveOutput.dataset.autoScroll = 'true';
+  if (livePreviewTargets.length) {
+    livePreviewTargets.forEach((output) => {
+      output.dataset.autoScroll = 'true';
+    });
   }
   updateLivePreview(cachedResults);
-  scrollContainerToEnd(liveOutput);
+  livePreviewTargets.forEach((output) => scrollContainerToEnd(output));
 });
 
 homePendingList?.addEventListener('click', (event) => {
@@ -2297,13 +2439,21 @@ homeFolderSummary?.addEventListener('click', (event) => {
 });
 
 homeRecentList?.addEventListener('click', (event) => {
-  const button = event.target.closest('[data-recent-id]');
-  if (!button) return;
-  const id = Number(button.getAttribute('data-recent-id'));
-  if (!Number.isFinite(id)) return;
-  selectedTranscriptionId = id;
-  updateLivePreview(cachedResults);
-  openModal(id);
+  const row = event.target.closest('[data-recent-id]');
+  if (!row) return;
+  const id = Number(row.getAttribute('data-recent-id'));
+  handleRecentSelection(id);
+});
+
+homeRecentList?.addEventListener('keydown', (event) => {
+  if (event.key !== 'Enter' && event.key !== ' ') {
+    return;
+  }
+  const row = event.target.closest('[data-recent-id]');
+  if (!row) return;
+  event.preventDefault();
+  const id = Number(row.getAttribute('data-recent-id'));
+  handleRecentSelection(id);
 });
 
 renderHomePendingList([]);
@@ -2384,7 +2534,17 @@ function updateMetricValue(element, key, value, formatter = (val) => val) {
 }
 
 function updateMetrics(items) {
-  if (!metricTotal && !metricCompleted && !metricProcessing && !metricPremium && !metricMinutes) {
+  if (
+    !metricTotal &&
+    !metricCompleted &&
+    !metricProcessing &&
+    !metricPremium &&
+    !metricMinutes &&
+    !metricMode &&
+    !metricModel &&
+    !metricTodayMinutes &&
+    !metricTodayCount
+  ) {
     return;
   }
   const safeItems = Array.isArray(items) ? items : [];
@@ -2393,12 +2553,48 @@ function updateMetrics(items) {
   const processing = safeItems.filter((item) => item.status === 'processing').length;
   const premium = safeItems.filter((item) => item.premium_enabled).length;
   const minutes = safeItems.reduce((acc, item) => acc + ((item.duration ?? 0) / 60), 0);
+  const now = new Date();
+  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const todayItems = safeItems.filter((item) => {
+    const timestamp = Date.parse(item?.updated_at || item?.created_at || '') || 0;
+    return timestamp >= startOfDay;
+  });
+  const todayCount = todayItems.length;
+  const todayMinutes = todayItems.reduce((acc, item) => acc + ((item.duration ?? 0) / 60), 0);
+  const deviceCounts = safeItems.reduce((acc, item) => {
+    const raw = (item?.device_preference || '').trim();
+    if (!raw) return acc;
+    const key = raw.toLowerCase();
+    if (!acc[key]) {
+      acc[key] = { count: 0, label: raw.toUpperCase() };
+    }
+    acc[key].count += 1;
+    return acc;
+  }, {});
+  const modelCounts = safeItems.reduce((acc, item) => {
+    const raw = (item?.model_size || '').trim();
+    if (!raw) return acc;
+    const key = raw.toLowerCase();
+    if (!acc[key]) {
+      acc[key] = { count: 0, label: raw };
+    }
+    acc[key].count += 1;
+    return acc;
+  }, {});
+  const topDevice = Object.values(deviceCounts)
+    .sort((a, b) => b.count - a.count)[0]?.label || '';
+  const topModel = Object.values(modelCounts)
+    .sort((a, b) => b.count - a.count)[0]?.label || '';
 
   updateMetricValue(metricTotal, 'total', total);
   updateMetricValue(metricCompleted, 'completed', completed);
   updateMetricValue(metricProcessing, 'processing', processing);
   updateMetricValue(metricPremium, 'premium', premium);
   updateMetricValue(metricMinutes, 'minutes', minutes, (val) => `${val.toFixed(1)} min`);
+  updateMetricValue(metricTodayMinutes, 'todayMinutes', todayMinutes, (val) => `Hoy: ${val.toFixed(1)} min`);
+  updateMetricValue(metricTodayCount, 'todayCount', todayCount, (val) => `Hoy: ${val}`);
+  updateMetricValue(metricMode, 'mode', topDevice, (val) => (val ? val : '—'));
+  updateMetricValue(metricModel, 'model', topModel, (val) => (val ? val : '—'));
 }
 
 function updateStudentPreview(item) {
@@ -2422,8 +2618,20 @@ function updateStudentPreview(item) {
 }
 
 function updateLivePreview(results) {
-  if (!liveOutput) return;
+  if (!livePreviewTargets.length) return;
   const safeResults = Array.isArray(results) ? results : [];
+  const renderToTargets = (item, options = {}) => {
+    livePreviewTargets.forEach((output) => {
+      renderStreamingView(output, item, options);
+    });
+  };
+  const resetTargets = (message) => {
+    livePreviewTargets.forEach((output) => {
+      resetStreamingContainer(output, message);
+      output.dataset.stream = 'false';
+    });
+  };
+
   if (selectedTranscriptionId) {
     const selected = safeResults.find((item) => item.id === selectedTranscriptionId);
     if (selected) {
@@ -2431,7 +2639,7 @@ function updateLivePreview(results) {
       if (selected.id !== currentLiveTranscriptionId || text !== currentLiveText) {
         currentLiveTranscriptionId = selected.id;
         currentLiveText = text;
-        renderStreamingView(liveOutput, selected, {
+        renderToTargets(selected, {
           placeholder: 'Procesando y transcribiendo en vivo…',
         });
         updateStudentPreview(selected);
@@ -2441,6 +2649,7 @@ function updateLivePreview(results) {
     }
     return;
   }
+
   const active =
     safeResults.find((item) => item.status === 'processing' && item.text) ||
     safeResults.find((item) => item.status === 'completed' && item.text);
@@ -2449,20 +2658,17 @@ function updateLivePreview(results) {
     if (active.id !== currentLiveTranscriptionId || text !== currentLiveText) {
       currentLiveTranscriptionId = active.id;
       currentLiveText = text;
-      renderStreamingView(liveOutput, active, {
+      renderToTargets(active, {
         placeholder: 'Procesando y transcribiendo en vivo…',
       });
       updateStudentPreview(active);
     }
     return;
   }
+
   currentLiveTranscriptionId = null;
   currentLiveText = '';
-  resetStreamingContainer(
-    liveOutput,
-    'Selecciona cualquier transcripción para previsualizarla aquí.',
-  );
-  liveOutput.dataset.stream = 'false';
+  resetTargets('Selecciona cualquier transcripción para previsualizarla aquí.');
   updateStudentPreview(null);
 }
 
@@ -2484,12 +2690,14 @@ async function openModal(id) {
     modal.hidden = false;
     const message = `No se pudo obtener la transcripción: ${error.message}`;
     modalText.textContent = message;
-    if (liveOutput) {
-      renderStreamingView(
-        liveOutput,
-        { text: message, status: 'completed' },
-        { autoScroll: false },
-      );
+    if (livePreviewTargets.length) {
+      livePreviewTargets.forEach((output) => {
+        renderStreamingView(
+          output,
+          { text: message, status: 'completed' },
+          { autoScroll: false },
+        );
+      });
     }
     resetCopyFeedback();
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,149 +13,378 @@
   </head>
   <body>
     <header class="app-bar">
-      <div class="brand">
-        <span class="brand-mark" aria-hidden="true">🎙️</span>
-        <span class="brand-name">Grabadora Pro</span>
+      <div class="app-bar__inner container">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">🎙️</span>
+          <span class="brand-name">Grabadora Pro</span>
+        </div>
+        <nav class="app-nav" aria-label="Navegación principal">
+          <button type="button" class="nav-link is-active" data-section-toggle="home" aria-current="page">Inicio</button>
+          <button type="button" class="nav-link" data-section-toggle="library">Biblioteca</button>
+          <button type="button" class="nav-link" data-section-toggle="live">En vivo</button>
+          <button type="button" class="nav-link" data-section-toggle="benefits">Beneficios</button>
+        </nav>
+        <button id="google-login" type="button" class="google-btn">
+          <span class="icon">🔐</span>
+          Iniciar sesión con Google
+        </button>
       </div>
-      <nav class="app-nav" aria-label="Navegación principal">
-        <button type="button" class="nav-link is-active" data-section-toggle="home" aria-current="page">Inicio</button>
-        <button type="button" class="nav-link" data-section-toggle="library">Biblioteca</button>
-        <button type="button" class="nav-link" data-section-toggle="live">En vivo</button>
-        <button type="button" class="nav-link" data-section-toggle="benefits">Beneficios</button>
-      </nav>
-      <button id="google-login" type="button" class="google-btn">
-        <span class="icon">🔐</span>
-        Iniciar sesión con Google
-      </button>
     </header>
 
-    <main class="layout">
+    <main class="app-main">
       <section class="main-section is-active" data-section="home">
-        <section class="hero" id="upload">
-          <div class="hero-content">
-            <h1>Transcribe sin complicaciones</h1>
-            <p>
-              Sube tus clases, prácticas o notas de voz y sigue la transcripción en vivo mientras trabajamos por ti.
-            </p>
-            <div class="hero-tags">
-              <span>WhisperX optimizado</span>
-              <span>Carpetas automáticas</span>
-              <span>Streaming en tiempo real</span>
+        <div class="container home-container">
+          <header class="view-header home-header">
+            <div class="home-header__intro">
+              <h1 class="view-title">Panel principal</h1>
+              <p class="section-lead">
+                Controla tus métricas, inicia transcripciones al vuelo y visualiza los últimos resultados sin abandonar la portada.
+              </p>
             </div>
-          </div>
-          <div class="hero-visual" aria-hidden="true">
-            <div class="wave"></div>
-            <div class="wave"></div>
-            <div class="wave"></div>
-          </div>
-        </section>
+            <div class="home-header__actions">
+              <label class="combo" for="home-folder-quick">
+                <span class="combo-label">Carpeta rápida</span>
+                <input
+                  id="home-folder-quick"
+                  type="text"
+                  placeholder="Crear o seleccionar"
+                  list="destination-folder-options"
+                  autocomplete="off"
+                />
+              </label>
+              <button type="button" class="primary" data-scroll-to="#upload-form">
+                <span class="icon">➕</span>
+                <span>Nueva transcripción</span>
+              </button>
+            </div>
+          </header>
 
-        <div class="home-dashboard">
-          <section class="card home-pending-card" aria-labelledby="home-pending-heading">
-            <div class="card-header">
-              <h2 id="home-pending-heading">Tareas pendientes</h2>
-              <p class="section-lead">Controla las transcripciones en curso y salta a la biblioteca cuando necesites más detalle.</p>
+          <section class="card metrics-card home-stats-card" aria-label="Estadísticas generales">
+            <h2 class="visually-hidden">Resumen de uso</h2>
+            <div class="metrics-grid">
+              <article class="metric">
+                <p class="metric-label">Minutos procesados</p>
+                <p class="metric-value metric-stack">
+                  <span data-metric="minutes">0 min</span>
+                  <span class="metric-sub" data-metric="todayMinutes">Hoy: 0</span>
+                </p>
+                <p class="metric-sub">Total acumulado y minutos diarios</p>
+              </article>
+              <article class="metric">
+                <p class="metric-label">Transcripciones</p>
+                <p class="metric-value metric-stack">
+                  <span data-metric="total">0</span>
+                  <span class="metric-sub" data-metric="todayCount">Hoy: 0</span>
+                </p>
+                <p class="metric-sub">Conteo histórico y diario</p>
+              </article>
+              <article class="metric">
+                <p class="metric-label">En cola</p>
+                <p class="metric-value" data-metric="processing">0</p>
+                <p class="metric-sub">Transcripciones pendientes</p>
+              </article>
+              <article class="metric">
+                <p class="metric-label">Modo actual</p>
+                <p class="metric-value metric-stack">
+                  <span data-metric="mode">GPU</span>
+                  <span data-metric="model">WhisperX large-v3</span>
+                </p>
+                <p class="metric-sub">Carga aproximada y modelo activo</p>
+              </article>
             </div>
-            <div class="home-pending-meta">
-              <span id="home-pending-count" class="badge badge-soft" aria-live="polite">Sin tareas en curso</span>
-              <button type="button" class="ghost" data-section-jump="library">Abrir cola completa</button>
-            </div>
-            <p id="home-pending-empty" class="home-pending-empty">No tienes transcripciones procesándose ahora mismo.</p>
-            <ul id="home-pending-list" class="home-pending-list" hidden aria-live="polite"></ul>
           </section>
 
-          <div class="home-columns">
-            <section class="card upload-card" aria-labelledby="upload-heading">
-              <div class="card-header">
-                <h2 id="upload-heading">Transcripción rápida</h2>
-                <p class="section-lead">
-                  Elige tus archivos, selecciona la carpeta de destino y deja que la app haga el resto.
-                </p>
-              </div>
-              <form id="upload-form" class="upload-form">
-                <div class="file-picker">
-                  <input
-                    id="audio-file"
-                    type="file"
-                    accept="audio/*,video/*"
-                    multiple
-                    hidden
-                  />
-                  <label for="audio-file" class="file-trigger" role="button" tabindex="0">
-                    <span class="file-trigger__pulse"></span>
-                    <span class="file-trigger__pulse"></span>
-                    <span class="icon">📁</span>
-                    <span class="text">Elegir archivos</span>
+          <div class="home-grid">
+            <div class="home-grid__primary">
+              <section class="card upload-card" aria-labelledby="upload-heading">
+                <div class="card-header">
+                  <h2 id="upload-heading">Transcripción rápida</h2>
+                  <p class="section-lead">
+                    Arrastra audio o video, selecciona destino y obtén el texto listo para copiar o descargar.
+                  </p>
+                </div>
+                <form id="upload-form" class="upload-form">
+                  <div class="file-picker">
+                    <input
+                      id="audio-file"
+                      type="file"
+                      accept="audio/*,video/*"
+                      multiple
+                      hidden
+                    />
+                    <label for="audio-file" class="file-trigger" role="button" tabindex="0">
+                      <span class="file-trigger__pulse"></span>
+                      <span class="file-trigger__pulse"></span>
+                      <span class="icon">📁</span>
+                      <span class="text">Elegir archivos</span>
+                    </label>
+                    <p class="hint">Formatos compatibles: mp3, wav, m4a, mp4, webm y más.</p>
+                  </div>
+                  <div id="file-preview" class="file-preview" hidden></div>
+                  <div id="file-error" class="form-error" hidden></div>
+
+                  <div class="field">
+                    <label class="form-label" for="destination-folder">Carpeta destino</label>
+                    <input
+                      id="destination-folder"
+                      type="text"
+                      name="destination_folder"
+                      placeholder="Ej: clase-historia"
+                      list="destination-folder-options"
+                      required
+                    />
+                    <datalist id="destination-folder-options"></datalist>
+                  </div>
+
+                  <details class="advanced-options">
+                    <summary>Opciones avanzadas</summary>
+                    <div class="form-grid">
+                      <div class="field">
+                        <label class="form-label" for="language">Idioma preferido</label>
+                        <select id="language" name="language">
+                          <option value="">Detección automática</option>
+                          <option value="es" selected>Español</option>
+                          <option value="en">Inglés</option>
+                          <option value="fr">Francés</option>
+                        </select>
+                      </div>
+
+                      <div class="field">
+                        <label class="form-label" for="model-size">Modelo WhisperX</label>
+                        <select id="model-size" name="model_size" data-default="large-v3">
+                          <option value="large-v3" selected>large-v3 (máxima precisión)</option>
+                          <option value="large-v2">large-v2 (estable)</option>
+                          <option value="medium">medium (equilibrado)</option>
+                          <option value="small">small (más veloz)</option>
+                        </select>
+                      </div>
+
+                      <div class="field">
+                        <label class="form-label" for="device-preference">Dispositivo preferido</label>
+                        <select id="device-preference" name="device_preference" data-default="gpu">
+                          <option value="gpu" selected>GPU / CUDA (recomendado)</option>
+                          <option value="cpu">CPU</option>
+                        </select>
+                      </div>
+                    </div>
+                  </details>
+
+                  <div class="live-inline-hint" id="destination-saved-hint" hidden>
+                    <span class="icon">💾</span>
+                    <span>Guardando última carpeta usada…</span>
+                  </div>
+
+                  <button type="submit" class="primary upload-button">
+                    <span class="glow"></span>
+                    <span class="label">Subir y transcribir</span>
+                  </button>
+                </form>
+                <div class="upload-feedback">
+                  <div id="upload-progress" class="progress-track" hidden>
+                    <div class="progress-bar"></div>
+                  </div>
+                  <div id="upload-status" class="upload-status" aria-live="polite"></div>
+                </div>
+              </section>
+
+              <section class="card home-library-card" aria-labelledby="home-library-heading">
+                <div class="card-header">
+                  <h2 id="home-library-heading">Biblioteca rápida</h2>
+                  <p class="section-lead">Ubica carpetas activas y abre los últimos procesos en segundos.</p>
+                </div>
+                <div class="home-library-content">
+                  <div class="home-folder-summary" id="home-folder-summary" aria-live="polite"></div>
+                  <div class="home-recent" aria-live="polite">
+                    <div class="home-recent-header">
+                      <h3>Últimas transcripciones</h3>
+                      <button type="button" class="ghost" data-section-jump="library">Ir a biblioteca</button>
+                    </div>
+                    <div class="home-recent-table" id="home-recent-list" role="region" aria-label="Transcripciones recientes"></div>
+                  </div>
+                </div>
+              </section>
+            </div>
+
+            <aside class="home-grid__secondary" aria-label="Panel de seguimiento">
+              <section class="card home-live-card" aria-labelledby="home-live-heading">
+                <div class="card-header">
+                  <h2 id="home-live-heading">Transcripción en vivo</h2>
+                  <p class="section-lead">Visualiza los últimos fragmentos de audio en tiempo real con control directo desde Inicio.</p>
+                </div>
+                <div class="home-live-preview">
+                  <div
+                    id="home-live-output"
+                    class="live-output live-output--compact"
+                    data-live-output
+                    aria-live="polite"
+                    data-auto-scroll-threshold="64"
+                  >
+                    Selecciona una transcripción o inicia una nueva grabación para verla aquí.
+                  </div>
+                  <div class="home-live-controls">
+                    <span id="home-live-status" class="home-live-status" aria-live="polite">Listo para empezar una sesión.</span>
+                    <div class="home-live-buttons">
+                      <button type="button" class="secondary" data-live-control="start">
+                        <span class="icon">▶️</span>
+                        <span>Iniciar</span>
+                      </button>
+                      <button type="button" class="ghost" data-live-control="pause">
+                        <span class="icon">⏸</span>
+                        <span>Pausar</span>
+                      </button>
+                      <button type="button" class="primary" data-live-control="finish">
+                        <span class="icon">💾</span>
+                        <span>Finalizar y guardar</span>
+                      </button>
+                    </div>
+                    <p class="home-live-helper">
+                      Los controles están sincronizados con el Centro en vivo para evitar duplicados.
+                    </p>
+                  </div>
+                </div>
+              </section>
+
+              <section class="card home-pending-card" aria-labelledby="home-pending-heading">
+                <div class="card-header">
+                  <h2 id="home-pending-heading">Tareas pendientes</h2>
+                  <p class="section-lead">Controla las transcripciones en curso y salta a la biblioteca cuando necesites más detalle.</p>
+                </div>
+                <div class="home-pending-meta">
+                  <span id="home-pending-count" class="badge badge-soft" aria-live="polite">Sin tareas en curso</span>
+                  <button type="button" class="ghost" data-section-jump="library">Abrir cola completa</button>
+                </div>
+                <p id="home-pending-empty" class="home-pending-empty">No tienes transcripciones procesándose ahora mismo.</p>
+                <ul id="home-pending-list" class="home-pending-list" hidden aria-live="polite"></ul>
+              </section>
+
+              <section class="card home-shortcuts" aria-labelledby="home-shortcuts-heading">
+                <div class="card-header">
+                  <h2 id="home-shortcuts-heading">Accesos rápidos</h2>
+                  <p class="section-lead">Navega entre vistas clave con un solo clic.</p>
+                </div>
+                <div class="home-shortcuts__grid">
+                  <button type="button" class="pill" data-section-jump="library">📂 Ver biblioteca completa</button>
+                  <button type="button" class="pill" data-section-jump="live">🎙️ Abrir centro en vivo</button>
+                  <button type="button" class="pill" data-section-jump="benefits">✨ Explorar beneficios</button>
+                </div>
+              </section>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section class="main-section" data-section="library" hidden>
+        <div class="container library-container">
+          <header class="view-header library-header">
+            <div class="library-header__intro">
+              <nav class="breadcrumbs" aria-label="Rastro de navegación">
+                <ol>
+                  <li><button type="button" data-section-jump="home">Inicio</button></li>
+                  <li aria-current="page">Biblioteca</li>
+                </ol>
+              </nav>
+              <h1 class="view-title">Biblioteca</h1>
+              <p class="section-lead">Gestiona carpetas, filtra por estado y revisa el avance de cada transcripción.</p>
+            </div>
+            <div class="library-header__actions">
+              <button type="button" class="primary" id="folder-create">Crear carpeta</button>
+              <button type="button" class="ghost" id="folder-manage">Gestionar selección</button>
+            </div>
+          </header>
+
+          <div class="library-layout">
+            <aside class="library-sidebar" aria-label="Carpetas">
+              <section class="card folder-tree-card" aria-labelledby="folder-tree-heading">
+                <div class="card-header">
+                  <h2 id="folder-tree-heading">Carpetas</h2>
+                  <p class="section-lead">Crea, renombra o mueve elementos directamente desde la barra lateral.</p>
+                </div>
+                <div class="folder-tree-actions">
+                  <button type="button" class="ghost" id="folder-add-root">Nueva carpeta</button>
+                  <button type="button" class="ghost" id="folder-add-child">Nueva subcarpeta</button>
+                </div>
+                <div id="folder-groups" class="folder-groups" aria-live="polite"></div>
+              </section>
+            </aside>
+
+            <div class="library-main">
+              <section class="card library-filters" aria-labelledby="library-filters-heading">
+                <div class="card-header">
+                  <h2 id="library-filters-heading">Filtros y organización</h2>
+                  <p class="section-lead">Refina resultados por tipo, estado, idioma o búsqueda libre.</p>
+                </div>
+                <div class="folders-controls" role="group" aria-labelledby="library-filters-heading">
+                  <label class="control" for="folder-category">
+                    <span>Tipo de carpeta</span>
+                    <select id="folder-category">
+                      <option value="all">Todas</option>
+                      <option value="temario">Temario</option>
+                      <option value="tema">Tema</option>
+                      <option value="practicas">Prácticas</option>
+                      <option value="ejercicios">Ejercicios</option>
+                      <option value="teoria">Teoría</option>
+                    </select>
                   </label>
-                  <p class="hint">Formatos compatibles: mp3, wav, m4a, mp4, webm y más.</p>
+                  <label class="control" for="folder-status">
+                    <span>Estado</span>
+                    <select id="folder-status">
+                      <option value="all">Todos</option>
+                      <option value="in-progress">En proceso</option>
+                      <option value="completed">Completadas</option>
+                      <option value="failed">Con errores</option>
+                      <option value="premium">Premium activado</option>
+                    </select>
+                  </label>
+                  <label class="control" for="folder-topic">
+                    <span>Número de tema</span>
+                    <select id="folder-topic">
+                      <option value="all">Todos</option>
+                    </select>
+                  </label>
+                  <label class="control" for="folder-search">
+                    <span>Buscar carpeta, asignatura o etiqueta</span>
+                    <input id="folder-search" type="search" placeholder="Ej: historia, tema 3, teoría" />
+                  </label>
+                  <div class="folders-controls__actions">
+                    <button id="folder-reset" type="button" class="ghost">Limpiar filtros</button>
+                  </div>
                 </div>
-                <div id="file-preview" class="file-preview" hidden></div>
-                <div id="file-error" class="form-error" hidden></div>
+              </section>
 
-                <div class="field">
-                  <label class="form-label" for="destination-folder">Carpeta destino</label>
-                  <input
-                    id="destination-folder"
-                    type="text"
-                    name="destination_folder"
-                    placeholder="Ej: clase-historia"
-                    list="destination-folder-options"
-                    required
-                  />
-                  <datalist id="destination-folder-options"></datalist>
-                </div>
+              <div id="system-alerts" class="system-alerts" hidden aria-live="polite"></div>
 
-                <details class="advanced-options">
-                  <summary>Opciones avanzadas</summary>
-                  <div class="form-grid">
-                    <div class="field">
-                      <label class="form-label" for="language">Idioma preferido</label>
-                      <select id="language" name="language">
-                        <option value="">Detección automática</option>
-                        <option value="es" selected>Español</option>
-                        <option value="en">Inglés</option>
-                        <option value="fr">Francés</option>
-                      </select>
+              <section class="card library-table-card" aria-labelledby="library-table-heading">
+                <div class="card-header">
+                  <div class="library-table-header">
+                    <div>
+                      <h2 id="library-table-heading">Transcripciones</h2>
+                      <p class="section-lead">Lista detallada con estado, duración y acciones rápidas.</p>
                     </div>
-
-                    <div class="field">
-                      <label class="form-label" for="model-size">Modelo WhisperX</label>
-                      <select id="model-size" name="model_size" data-default="large-v3">
-                        <option value="large-v3" selected>large-v3 (máxima precisión)</option>
-                        <option value="large-v2">large-v2 (estable)</option>
-                        <option value="medium">medium (equilibrado)</option>
-                        <option value="small">small (más veloz)</option>
-                      </select>
-                    </div>
-
-                    <div class="field">
-                      <label class="form-label" for="device-preference">Dispositivo preferido</label>
-                      <select id="device-preference" name="device_preference" data-default="gpu">
-                        <option value="gpu" selected>GPU / CUDA (recomendado)</option>
-                        <option value="cpu">CPU</option>
-                      </select>
+                    <div class="library-table-search">
+                      <label for="search" class="visually-hidden">Buscar transcripciones</label>
+                      <input id="search" type="search" placeholder="Buscar por texto, asignatura o estado" />
                     </div>
                   </div>
-                </details>
-
-                <div class="live-inline-hint" id="destination-saved-hint" hidden>
-                  <span class="icon">💾</span>
-                  <span>Guardando última carpeta usada…</span>
+                  <div class="library-table-filters">
+                    <label class="checkbox">
+                      <input type="checkbox" id="filter-premium" /> Solo premium
+                    </label>
+                  </div>
                 </div>
+                <div id="transcription-list" class="transcription-list" role="region" aria-live="polite"></div>
+              </section>
+            </div>
+          </div>
+        </div>
+      </section>
 
-                <button type="submit" class="primary upload-button">
-                  <span class="glow"></span>
-                  <span class="label">Subir y transcribir</span>
-                </button>
-              </form>
-              <div class="upload-feedback">
-                <div id="upload-progress" class="progress-track" hidden>
-                  <div class="progress-bar"></div>
-                </div>
-                <div id="upload-status" class="upload-status" aria-live="polite"></div>
-              </div>
-            </section>
-
+      <section class="main-section" data-section="live" hidden>
+        <div class="container">
+          <header class="view-header">
+            <h1 class="view-title">Centro en vivo</h1>
+            <p class="section-lead">Monitorea tu sesión de streaming mientras gestionas la configuración y diagnósticos.</p>
+          </header>
+          <div class="live-layout">
             <section class="card live-stream-card" aria-labelledby="live-stream-heading">
               <div class="card-header">
                 <h2 id="live-stream-heading">Transcripción en línea</h2>
@@ -220,9 +449,13 @@
                       <span class="icon">🎙️</span>
                       <span>Iniciar transmisión</span>
                     </button>
+                    <button type="button" id="live-pause" class="ghost" disabled>
+                      <span class="icon">⏸</span>
+                      <span>Pausar</span>
+                    </button>
                     <button type="button" id="live-stop" class="secondary" disabled>
-                      <span class="icon">⏹</span>
-                      <span>Detener y guardar</span>
+                      <span class="icon">💾</span>
+                      <span>Finalizar y guardar</span>
                     </button>
                     <button type="button" id="live-reset" class="ghost" disabled>
                       <span class="icon">🧹</span>
@@ -236,179 +469,211 @@
                   <div class="live-stream-status" id="live-stream-status" role="status" aria-live="polite">
                     Tu texto aparecerá aquí cuando empieces a hablar.
                   </div>
+                  <dl class="live-kpi-grid">
+                    <div>
+                      <dt>Palabras / min</dt>
+                      <dd data-live-kpi="wpm">0</dd>
+                    </div>
+                    <div>
+                      <dt>Latencia</dt>
+                      <dd data-live-kpi="latency">— ms</dd>
+                    </div>
+                    <div>
+                      <dt>Chunks perdidos</dt>
+                      <dd data-live-kpi="dropped">0</dd>
+                    </div>
+                  </dl>
                   <div id="live-stream-output" class="live-stream-output" aria-live="polite"></div>
                 </div>
               </div>
+            </section>
 
-              <div class="live-preview-panel">
-                <div class="live-preview-header">
-                  <h3 class="live-panel-title">Vista en vivo instantánea</h3>
-                  <p class="live-panel-lead">Selecciona una transcripción para seguir el texto conforme llega cada segmento con auto-scroll.</p>
-                </div>
-                <div id="live-output" class="live-output" aria-live="polite">
-                  Selecciona cualquier transcripción para previsualizarla aquí.
-                </div>
+            <section class="card live-preview-card" aria-labelledby="live-preview-heading">
+              <div class="live-preview-header">
+                <h2 id="live-preview-heading" class="live-panel-title">Vista en vivo instantánea</h2>
+                <p class="live-panel-lead">Selecciona una transcripción para seguir el texto conforme llega cada segmento con auto-scroll.</p>
+              </div>
+              <div id="live-output" class="live-output" data-live-output aria-live="polite">
+                Selecciona cualquier transcripción para previsualizarla aquí.
               </div>
             </section>
+          </div>
+
+          <section class="card span-2 live-info-card" aria-labelledby="live-info-heading">
+            <div class="card-header">
+              <h2 id="live-info-heading">Guía y diagnósticos</h2>
+              <p class="section-lead">Consejos para mantener tus sesiones en vivo funcionando al máximo.</p>
+            </div>
+            <ul class="live-info-list">
+              <li>Comprueba el micrófono y otorga permisos antes de iniciar la transmisión.</li>
+              <li>Usa <strong>GPU / CUDA</strong> para sesiones largas y alterna a CPU si necesitas compatibilidad universal.</li>
+              <li>Las carpetas se sincronizan automáticamente: selecciona un destino para ordenar el material en segundos.</li>
+            </ul>
+          </section>
+
+          <section class="card span-2 student-card" id="student-web" aria-labelledby="student-heading">
+            <div class="card-header">
+              <h2 id="student-heading">Modo estudiante en web</h2>
+              <p class="section-lead">Observa cómo se ejecuta la edición ligera con anuncios y computación local pensada para campus.</p>
+            </div>
+            <div class="student-controls">
+              <button id="open-student-web" type="button" class="primary-alt">Abrir simulador independiente</button>
+              <label class="toggle" for="student-follow">
+                <input id="student-follow" type="checkbox" checked />
+                <span>Sincronizar con la transcripción activa</span>
+              </label>
+            </div>
+            <div id="student-web-preview" class="student-preview">
+              <div class="student-preview__header">
+                <span>Vista previa incrustada</span>
+                <span class="badge">Plan estudiante</span>
+              </div>
+              <div id="student-preview-body" class="student-preview__body" aria-live="polite">
+                <p class="placeholder">Se vinculará automáticamente a la transcripción que esté en proceso.</p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </section>
+
+      <section class="main-section" data-section="job-detail" hidden>
+        <div class="container job-detail-container">
+          <header class="view-header job-header">
+            <div class="job-header__intro">
+              <nav class="breadcrumbs" aria-label="Rastro de navegación">
+                <ol id="job-breadcrumbs">
+                  <li><button type="button" data-section-jump="home">Inicio</button></li>
+                  <li><button type="button" data-section-jump="library">Biblioteca</button></li>
+                  <li aria-current="page">Detalle del proceso</li>
+                </ol>
+              </nav>
+              <h1 id="job-title" class="view-title">Transcripción seleccionada</h1>
+              <p id="job-subtitle" class="section-lead">Consulta texto consolidado, descárgalo o muévelo de carpeta.</p>
+            </div>
+            <div class="job-header__actions">
+              <button type="button" class="ghost" id="job-move">Mover de carpeta</button>
+              <button type="button" class="primary" id="job-copy">Copiar texto</button>
+              <a class="secondary" id="job-download" href="#" download>Descargar .txt</a>
+            </div>
+          </header>
+
+          <div class="job-layout">
+            <article class="card job-text-card" aria-labelledby="job-text-heading">
+              <div class="card-header">
+                <h2 id="job-text-heading">Texto completo</h2>
+                <p class="section-lead">El visor sigue el streaming mientras se procesa y se consolida al finalizar.</p>
+              </div>
+              <div class="job-text-toolbar">
+                <label class="toggle" for="job-follow">
+                  <input id="job-follow" type="checkbox" checked />
+                  <span>Seguir al final automáticamente</span>
+                </label>
+                <label class="combo" for="job-tail-size">
+                  <span class="combo-label">Segmentos visibles</span>
+                  <select id="job-tail-size">
+                    <option value="50">50</option>
+                    <option value="200" selected>200</option>
+                    <option value="500">500</option>
+                    <option value="1000">1000</option>
+                  </select>
+                </label>
+              </div>
+              <div id="job-text" class="job-text" aria-live="polite">
+                <p class="placeholder">Selecciona una transcripción reciente para ver su contenido aquí.</p>
+              </div>
+              <div class="job-text-actions">
+                <button type="button" class="ghost" id="job-export-srt">Descargar .srt</button>
+                <button type="button" class="ghost" id="job-export-md">Exportar Markdown</button>
+              </div>
+            </article>
+
+            <aside class="job-meta" aria-label="Información adicional">
+              <section class="card job-meta-card" aria-labelledby="job-meta-heading">
+                <div class="card-header">
+                  <h2 id="job-meta-heading">Metadatos</h2>
+                  <p class="section-lead">Idioma detectado, modelo, duración y enlaces a recursos asociados.</p>
+                </div>
+                <dl class="job-meta-list" id="job-meta-list">
+                  <div>
+                    <dt>Estado</dt>
+                    <dd id="job-status">—</dd>
+                  </div>
+                  <div>
+                    <dt>Carpeta</dt>
+                    <dd id="job-folder">—</dd>
+                  </div>
+                  <div>
+                    <dt>Duración</dt>
+                    <dd id="job-duration">—</dd>
+                  </div>
+                  <div>
+                    <dt>Idioma</dt>
+                    <dd id="job-language">—</dd>
+                  </div>
+                  <div>
+                    <dt>Modelo</dt>
+                    <dd id="job-model">—</dd>
+                  </div>
+                  <div>
+                    <dt>WER estimada</dt>
+                    <dd id="job-wer">—</dd>
+                  </div>
+                </dl>
+              </section>
+
+              <section class="card job-links" aria-labelledby="job-links-heading">
+                <div class="card-header">
+                  <h2 id="job-links-heading">Recursos</h2>
+                </div>
+                <ul class="job-links-list">
+                  <li><a id="job-audio" href="#" target="_blank" rel="noopener">Audio original</a></li>
+                  <li><a id="job-logs" href="#" target="_blank" rel="noopener">Ver logs</a></li>
+                </ul>
+              </section>
+            </aside>
           </div>
         </div>
       </section>
 
-      <section class="main-section" data-section="library" hidden>
-        <section class="card span-2 folders-card" id="folders" aria-labelledby="folders-heading">
-          <div class="card-header">
-            <h2 id="folders-heading">Biblioteca por carpetas</h2>
-            <p class="section-lead">Revisa tus carpetas ordenadas por fecha y filtra por tipo de contenido.</p>
-          </div>
-          <div id="system-alerts" class="system-alerts" hidden aria-live="polite"></div>
-          <div class="folders-controls">
-            <label class="control" for="folder-category">
-              <span>Etiqueta</span>
-              <select id="folder-category">
-                <option value="all">Todas</option>
-                <option value="temario">Temario</option>
-                <option value="tema">Tema</option>
-                <option value="practicas">Prácticas</option>
-                <option value="ejercicios">Ejercicios</option>
-                <option value="teoria">Teoría</option>
-              </select>
-            </label>
-            <label class="control" for="folder-status">
-              <span>Estado</span>
-              <select id="folder-status">
-                <option value="all">Todos</option>
-                <option value="in-progress">En progreso</option>
-                <option value="completed">Completadas</option>
-                <option value="failed">Con error</option>
-                <option value="premium">Premium</option>
-              </select>
-            </label>
-            <label class="control" for="folder-topic">
-              <span>Número de tema</span>
-              <select id="folder-topic">
-                <option value="all">Todos</option>
-              </select>
-            </label>
-            <label class="control control--wide" for="folder-search">
-              <span>Buscar carpeta, asignatura o etiqueta</span>
-              <input id="folder-search" type="search" placeholder="Ej: historia, tema 3, teoría" />
-            </label>
-            <button id="folder-reset" type="button" class="ghost">Limpiar filtros</button>
-          </div>
-          <div id="folder-groups" class="folder-groups" aria-live="polite"></div>
-        </section>
-
-        <section class="card metrics-card" aria-label="Resumen de actividad">
-          <h2 class="visually-hidden">Resumen de actividad</h2>
-          <div class="metrics-grid">
-            <article class="metric">
-              <p class="metric-label">Transcripciones</p>
-              <p class="metric-value" data-metric="total">0</p>
-              <p class="metric-sub">Historial total en la plataforma</p>
-            </article>
-            <article class="metric">
-              <p class="metric-label">Completadas</p>
-              <p class="metric-value" data-metric="completed">0</p>
-              <p class="metric-sub">Listas para descargar</p>
-            </article>
-            <article class="metric">
-              <p class="metric-label">En cola</p>
-              <p class="metric-value" data-metric="processing">0</p>
-              <p class="metric-sub">Procesándose en tiempo real</p>
-            </article>
-            <article class="metric">
-              <p class="metric-label">Premium &nbsp;|&nbsp; Minutos</p>
-              <p class="metric-value metric-stack">
-                <span data-metric="premium">0</span>
-                <span data-metric="minutes">0 min</span>
-              </p>
-              <p class="metric-sub">Clientes con IA + duración agregada</p>
-            </article>
-          </div>
-        </section>
-
-        <section class="card" id="recientes">
-          <div class="list-header">
-            <h2>Transcripciones recientes</h2>
-            <input id="search" type="search" placeholder="Buscar por texto, asignatura o estado" />
-          </div>
-          <div class="filters">
-            <label><input type="checkbox" id="filter-premium" /> Solo premium</label>
-          </div>
-          <div id="transcription-list" class="transcription-list"></div>
-        </section>
-      </section>
-      <section class="main-section" data-section="live" hidden>
-        <section class="card span-2 live-info-card" aria-labelledby="live-info-heading">
-          <div class="card-header">
-            <h2 id="live-info-heading">Centro en vivo</h2>
-            <p class="section-lead">Inicia tus sesiones desde Inicio y consulta aquí recursos y diagnósticos adicionales.</p>
-          </div>
-          <ul class="live-info-list">
-            <li><strong>Transcripción en línea</strong> ahora vive en la pestaña Inicio para que grabes y transcribas sin cambiar de vista.</li>
-            <li>La <em>Vista en vivo instantánea</em> también está en Inicio y mantiene el auto-scroll activo mientras llegan nuevos bloques.</li>
-            <li>Si detectamos problemas con CUDA o el modelo, verás avisos en la Biblioteca con los pasos sugeridos para solucionarlo.</li>
-          </ul>
-        </section>
-
-        <section class="card span-2 student-card" id="student-web" aria-labelledby="student-heading">
-          <div class="card-header">
-            <h2 id="student-heading">Modo estudiante en web</h2>
-            <p class="section-lead">Observa cómo se ejecuta la edición ligera con anuncios y computación local pensada para campus.</p>
-          </div>
-          <div class="student-controls">
-            <button id="open-student-web" type="button" class="primary-alt">Abrir simulador independiente</button>
-            <label class="toggle" for="student-follow">
-              <input id="student-follow" type="checkbox" checked />
-              <span>Sincronizar con la transcripción activa</span>
-            </label>
-          </div>
-          <div id="student-web-preview" class="student-preview">
-            <div class="student-preview__header">
-              <span>Vista previa incrustada</span>
-              <span class="badge">Plan estudiante</span>
-            </div>
-            <div id="student-preview-body" class="student-preview__body" aria-live="polite">
-              <p class="placeholder">Se vinculará automáticamente a la transcripción que esté en proceso.</p>
-            </div>
-          </div>
-        </section>
-      </section>
       <section class="main-section" data-section="benefits" hidden>
-        <section class="card" id="planes">
-          <div class="list-header">
-            <h2>Beneficios premium</h2>
-            <button id="refresh-plans" type="button" class="ghost">Actualizar</button>
-          </div>
-          <p class="section-lead">Desbloquea notas IA, resúmenes estructurados y recordatorios inteligentes en cada transcripción.</p>
-          <div id="plans" class="plans"></div>
-          <div id="checkout-status" class="checkout-status" aria-live="polite"></div>
-        </section>
+        <div class="container">
+          <div class="view-grid">
+            <section class="card" id="planes">
+              <div class="list-header">
+                <h2>Beneficios premium</h2>
+                <button id="refresh-plans" type="button" class="ghost">Actualizar</button>
+              </div>
+              <p class="section-lead">Desbloquea notas IA, resúmenes estructurados y recordatorios inteligentes en cada transcripción.</p>
+              <div id="plans" class="plans"></div>
+              <div id="checkout-status" class="checkout-status" aria-live="polite"></div>
+            </section>
 
-        <section class="card span-2 about-card" id="about">
-          <div class="card-header">
-            <h2>Sobre mí</h2>
-            <p class="section-lead">Hola, soy FERIA. Construyo herramientas que convierten tus grabaciones en apuntes claros y accionables.</p>
+            <section class="card span-2 about-card" id="about">
+              <div class="card-header">
+                <h2>Sobre mí</h2>
+                <p class="section-lead">Hola, soy FERIA. Construyo herramientas que convierten tus grabaciones en apuntes claros y accionables.</p>
+              </div>
+              <div class="about-grid">
+                <article>
+                  <h3>Visión</h3>
+                  <p>Facilitar que estudiantes y profesionales capturen ideas sin preocuparse por el teclado. La aplicación detecta ponentes, resume y prepara notas premium listas para compartir.</p>
+                </article>
+                <article>
+                  <h3>Funcionalidades destacadas</h3>
+                  <ul>
+                    <li>Diarización por voz con WhisperX optimizado para GPU.</li>
+                    <li>Notas premium generadas automáticamente en segundos.</li>
+                    <li>Panel visual con métricas animadas y vista estilo ChatGPT.</li>
+                  </ul>
+                </article>
+                <article>
+                  <h3>Próximos pasos</h3>
+                  <p>Integrar recordatorios inteligentes, exportación a Notion y compatibilidad con más idiomas. Tus sugerencias son bienvenidas.</p>
+                </article>
+              </div>
+            </section>
           </div>
-          <div class="about-grid">
-            <article>
-              <h3>Visión</h3>
-              <p>Facilitar que estudiantes y profesionales capturen ideas sin preocuparse por el teclado. La aplicación detecta ponentes, resume y prepara notas premium listas para compartir.</p>
-            </article>
-            <article>
-              <h3>Funcionalidades destacadas</h3>
-              <ul>
-                <li>Diarización por voz con WhisperX optimizado para GPU.</li>
-                <li>Notas premium generadas automáticamente en segundos.</li>
-                <li>Panel visual con métricas animadas y vista estilo ChatGPT.</li>
-              </ul>
-            </article>
-            <article>
-              <h3>Próximos pasos</h3>
-              <p>Integrar recordatorios inteligentes, exportación a Notion y compatibilidad con más idiomas. Tus sugerencias son bienvenidas.</p>
-            </article>
-          </div>
-        </section>
+        </div>
       </section>
     </main>
 
@@ -461,7 +726,9 @@
 
     <script src="app.js" type="module"></script>
     <footer class="app-footer">
-      <p>© 2024 FERIA · Creado con cariño para acelerar tus apuntes</p>
+      <div class="container">
+        <p>© 2024 FERIA · Creado con cariño para acelerar tus apuntes</p>
+      </div>
     </footer>
   </body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -118,11 +118,38 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  background: transparent;
+  color: inherit;
 }
 
 html {
   scroll-behavior: smooth;
+  min-height: 100%;
+}
+
+.container {
+  width: 100%;
+  max-width: 1180px;
+  margin-inline: auto;
+  padding-inline: clamp(1.25rem, 5vw, 2.5rem);
+}
+
+.app-main {
+  flex: 1;
+  padding: 2.5rem 0 4rem;
+}
+
+.main-section {
+  display: none;
+}
+
+.main-section.is-active {
+  display: block;
+}
+
+.main-section > .container {
+  display: grid;
+  gap: 2.5rem;
 }
 
 .visually-hidden {
@@ -138,18 +165,21 @@ html {
 }
 
 .app-bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(18px);
+  background: rgba(8, 15, 32, 0.55);
+  border-bottom: 1px solid rgba(99, 102, 241, 0.22);
+}
+
+.app-bar__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem 2rem;
   flex-wrap: wrap;
-  padding: 1.25rem clamp(1.5rem, 3vw, 3rem);
-  backdrop-filter: blur(18px);
-  background: rgba(8, 15, 32, 0.55);
-  border-bottom: 1px solid rgba(99, 102, 241, 0.22);
-  position: sticky;
-  top: 0;
-  z-index: 10;
+  padding-block: 1.25rem;
 }
 
 .brand {
@@ -231,9 +261,8 @@ html {
 }
 
 @media (max-width: 960px) {
-  .app-bar {
+  .app-bar__inner {
     justify-content: center;
-    flex-wrap: wrap;
   }
 
   .brand {
@@ -332,22 +361,6 @@ html {
   animation-delay: 4s;
 }
 
-.layout {
-  width: min(1180px, 94vw);
-  margin: 0 auto 4rem;
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-}
-
-.main-section {
-  display: none;
-}
-
-.main-section.is-active {
-  display: contents;
-}
-
 .metrics-card {
   position: relative;
   overflow: hidden;
@@ -436,14 +449,6 @@ html {
   .span-2 {
     grid-column: span 1;
   }
-  .app-nav {
-    order: 2;
-    width: 100%;
-    justify-content: flex-start;
-    overflow-x: auto;
-    padding: 0.5rem 0 0;
-    gap: 0.75rem;
-  }
 }
 
 .card {
@@ -456,26 +461,31 @@ html {
   gap: 1.25rem;
 }
 
-.home-dashboard {
+.home-layout {
   display: grid;
   gap: 2.5rem;
   align-items: start;
 }
 
-.home-columns {
+.home-layout__main {
   display: grid;
   gap: 2rem;
 }
 
+.home-layout__side {
+  display: grid;
+  gap: 1.5rem;
+}
+
 @media (min-width: 900px) {
-  .home-columns {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .home-layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
   }
 }
 
 @media (min-width: 1280px) {
-  .home-columns {
-    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.6fr);
+  .home-layout {
+    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
   }
 }
 
@@ -485,9 +495,79 @@ html {
   }
 }
 
+.view-header {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 2.25rem;
+}
+
+.view-title {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.view-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 880px) {
+  .view-grid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+}
+
 .home-pending-card {
   display: grid;
   gap: 1.2rem;
+}
+
+.home-shortcuts__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.home-live-card {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.home-live-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 720px) {
+  .home-live-actions {
+    justify-content: flex-start;
+  }
+}
+
+.pill {
+  background: rgba(99, 102, 241, 0.16);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  color: #e0e7ff;
+  border-radius: 999px;
+  padding: 0.55rem 1.15rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  font-family: inherit;
+}
+
+.pill:hover,
+.pill:focus-visible {
+  background: rgba(129, 140, 248, 0.28);
+  border-color: rgba(129, 140, 248, 0.5);
+  transform: translateY(-1px);
+}
+
+.pill:active {
+  transform: translateY(0);
 }
 
 .home-pending-meta {
@@ -597,132 +677,161 @@ html {
   justify-content: flex-end;
 }
 
-.home-folder-summary {
+.home-library-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.home-library-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(99, 102, 241, 0.16), transparent 55%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.home-library-card > * {
+  position: relative;
+}
+
+.home-library-content {
   display: grid;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
-.home-folder-summary__empty {
-  margin: 0;
-  color: #94a3b8;
+@media (min-width: 920px) {
+  .home-library-content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
-.home-folder-summary__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.9rem;
+.home-library-actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
-.home-folder-summary__button {
-  width: 100%;
-  text-align: left;
-  display: grid;
-  gap: 0.35rem;
-  padding: 1rem 1.2rem;
-  border-radius: 16px;
-  border: 1px solid rgba(99, 102, 241, 0.24);
-  background: rgba(15, 23, 42, 0.55);
-  color: inherit;
-  cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease;
-}
-
-.home-folder-summary__button:hover,
-.home-folder-summary__button:focus-visible {
-  border-color: var(--accent);
-  transform: translateY(-2px);
-}
-
-.home-folder-summary__name {
-  font-weight: 600;
-  font-size: 1rem;
-}
-
-.home-folder-summary__meta {
-  color: #cbd5f5;
-  font-size: 0.85rem;
-}
-
-.home-folder-summary__tags,
-.home-folder-summary__subjects {
-  font-size: 0.8rem;
-  color: #94a3b8;
-}
-
-.home-folder-summary__badge {
-  justify-self: start;
-  padding: 0.15rem 0.6rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  background: rgba(250, 204, 21, 0.14);
-  color: #facc15;
-}
-
-.home-folder-summary__badge.is-error {
-  background: rgba(248, 113, 113, 0.18);
-  color: #f87171;
-}
-
+.home-folder-summary,
 .home-recent-list {
   display: grid;
   gap: 1rem;
 }
 
+.home-folder-summary__empty,
 .home-recent-list__empty {
   margin: 0;
-  color: #94a3b8;
+  padding: 1rem 1.15rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  color: rgba(203, 213, 225, 0.85);
 }
 
+.home-folder-summary__list,
 .home-recent-list__list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.9rem;
+  gap: 0.85rem;
 }
 
+.home-folder-summary__item,
+.home-recent-list__item {
+  margin: 0;
+}
+
+.home-folder-summary__button,
 .home-recent-list__button {
   width: 100%;
-  text-align: left;
-  display: grid;
-  gap: 0.3rem;
-  padding: 1rem 1.2rem;
-  border-radius: 16px;
   border: 1px solid rgba(99, 102, 241, 0.18);
-  background: rgba(15, 23, 42, 0.5);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.55);
+  padding: 0.85rem 1rem;
+  display: grid;
+  gap: 0.35rem;
+  text-align: left;
   color: inherit;
+  font-family: inherit;
   cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
+.home-folder-summary__button:hover,
+.home-folder-summary__button:focus-visible,
 .home-recent-list__button:hover,
 .home-recent-list__button:focus-visible {
-  border-color: var(--accent);
-  transform: translateY(-2px);
+  border-color: rgba(129, 140, 248, 0.45);
+  background: rgba(99, 102, 241, 0.18);
+  transform: translateY(-1px);
 }
 
+.home-folder-summary__name,
 .home-recent-list__title {
+  font-size: 1rem;
   font-weight: 600;
+  color: #f8fafc;
 }
 
+.home-folder-summary__meta,
+.home-recent-list__meta,
 .home-recent-list__folder {
-  color: #cbd5f5;
   font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.75);
 }
 
-.home-recent-list__meta {
-  color: #94a3b8;
-  font-size: 0.82rem;
+.home-folder-summary__tags,
+.home-folder-summary__subjects {
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.home-folder-summary__tags {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.home-folder-summary__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.home-folder-summary__badge.is-warning {
+  background: rgba(251, 191, 36, 0.16);
+  color: #facc15;
+  border: 1px solid rgba(250, 204, 21, 0.4);
+}
+
+.home-folder-summary__badge.is-error {
+  background: rgba(248, 113, 113, 0.16);
+  color: #fca5a5;
+  border: 1px solid rgba(248, 113, 113, 0.4);
 }
 
 .home-recent-list__excerpt {
-  color: #e2e8f0;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
+  color: rgba(148, 163, 184, 0.85);
   line-height: 1.4;
+}
+
+.home-recent-list__folder {
+  font-weight: 600;
+}
+
+.home-recent-list__button::after {
+  content: 'Abrir';
+  justify-self: end;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
 }
 
 .live-info-card {
@@ -1049,6 +1158,18 @@ select:focus {
   font-size: 1rem;
 }
 
+.live-layout {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1200px) {
+  .live-layout {
+    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
 .live-stream-card {
   display: flex;
   flex-direction: column;
@@ -1078,6 +1199,11 @@ select:focus {
 }
 
 .live-preview-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.live-preview-card {
   display: grid;
   gap: 1rem;
 }
@@ -1206,6 +1332,11 @@ select:focus {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
+}
+
+.live-output--compact {
+  min-height: 150px;
+  max-height: 260px;
 }
 
 .live-output[data-stream="true"] {
@@ -1358,6 +1489,17 @@ select:focus {
   color: #94a3b8;
 }
 
+.folders-controls__actions {
+  display: flex;
+  align-items: flex-end;
+  min-width: 120px;
+  margin-left: auto;
+}
+
+.folders-controls__actions button {
+  width: 100%;
+}
+
 .control--wide {
   flex: 1 1 240px;
 }
@@ -1384,6 +1526,7 @@ select:focus {
   padding: 0.85rem 1rem;
   display: grid;
   gap: 0.45rem;
+  margin: 1.5rem 0;
 }
 
 .system-alerts p {
@@ -1828,7 +1971,8 @@ select:focus {
 button,
 .actions button,
 .ghost,
-.primary {
+.primary,
+.secondary {
   font-weight: 600;
   border-radius: 12px;
   padding: 0.75rem 1rem;
@@ -1839,7 +1983,8 @@ button,
 
 button:hover,
 .actions button:hover,
-.primary:hover {
+.primary:hover,
+.secondary:hover {
   transform: translateY(-1px);
 }
 
@@ -2063,11 +2208,14 @@ button:hover,
 }
 
 .app-footer {
-  margin-top: 3rem;
-  padding: 1.5rem 1rem 2.5rem;
-  text-align: center;
+  margin-top: auto;
+  padding: 2.5rem 0 3rem;
   color: #94a3b8;
   font-size: 0.95rem;
+}
+
+.app-footer .container {
+  text-align: center;
 }
 
 .modal {
@@ -2146,7 +2294,482 @@ button:hover,
     padding: 2rem 5vw 0.5rem;
   }
 
-  .layout {
-    width: min(96vw, 560px);
+  .folders-controls__actions {
+    flex: 1 1 100%;
+    margin-left: 0;
+  }
+}
+/* Redesigned layout additions */
+.home-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.home-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.home-header__intro {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 48rem;
+}
+
+.home-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.combo {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 220px;
+}
+
+.combo input,
+.combo select {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 0.65rem 0.8rem;
+  color: inherit;
+}
+
+.combo input:focus,
+.combo select:focus {
+  outline: none;
+  border-color: rgba(129, 140, 248, 0.75);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.combo-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 255, 0.72);
+}
+
+.home-stats-card .metrics-grid {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.home-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.home-grid__primary,
+.home-grid__secondary {
+  display: grid;
+  gap: 1.8rem;
+  align-content: start;
+}
+
+@media (min-width: 1080px) {
+  .home-grid {
+    grid-template-columns: minmax(0, 1.65fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.home-recent {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.home-recent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.home-recent-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.home-recent-table__table {
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.home-recent-table__table th,
+.home-recent-table__table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.92rem;
+}
+
+.home-recent-table__table th {
+  background: rgba(99, 102, 241, 0.12);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 255, 0.75);
+}
+
+.home-recent-table__table tbody tr {
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+
+.home-recent-table__table tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.home-recent-table__table tbody tr:hover {
+  background: rgba(99, 102, 241, 0.18);
+  transform: translateY(-1px);
+}
+
+.home-recent-table__table tbody tr:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.8);
+  outline-offset: -2px;
+}
+
+.home-recent-table__table td:first-child {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.home-live-preview {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.home-live-controls {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.home-live-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.home-live-status {
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.9);
+}
+
+.home-live-status[data-state='error'] {
+  color: var(--danger);
+}
+
+.home-live-helper {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.live-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+  margin: 1.1rem 0 0.4rem;
+}
+
+.live-kpi-grid div {
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  border-radius: 14px;
+  padding: 0.65rem 0.8rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.live-kpi-grid dt {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.8);
+  margin: 0;
+}
+
+.live-kpi-grid dd {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0;
+  color: #e0e7ff;
+}
+
+.secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  background: rgba(99, 102, 241, 0.24);
+  border: 1px solid rgba(129, 140, 248, 0.5);
+  color: #e0e7ff;
+}
+
+.secondary:hover {
+  background: rgba(129, 140, 248, 0.35);
+}
+
+button:disabled,
+button[disabled],
+.secondary[aria-disabled='true'] {
+  opacity: 0.48;
+  cursor: not-allowed;
+  transform: none !important;
+  pointer-events: none;
+}
+
+.library-container,
+.job-detail-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.library-header,
+.job-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.library-header__intro,
+.job-header__intro {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.library-header__actions,
+.job-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.breadcrumbs {
+  margin: 0;
+  padding: 0;
+}
+
+.breadcrumbs ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.breadcrumbs li {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+}
+
+.breadcrumbs li + li::before {
+  content: '›';
+  opacity: 0.5;
+}
+
+.breadcrumbs button {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-decoration-color: rgba(148, 163, 184, 0.55);
+}
+
+.library-layout {
+  display: grid;
+  gap: 2rem;
+}
+
+.library-sidebar,
+.library-main {
+  display: grid;
+  gap: 1.6rem;
+  align-content: start;
+}
+
+@media (min-width: 1120px) {
+  .library-layout {
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.folder-tree-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.library-filters .folders-controls {
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.library-table-card {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.library-table-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.library-table-search {
+  min-width: 240px;
+}
+
+.library-table-search input {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 0.65rem 0.85rem;
+  color: inherit;
+}
+
+.library-table-search input:focus {
+  outline: none;
+  border-color: rgba(129, 140, 248, 0.75);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.library-table-filters {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.library-table-filters .checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.82);
+}
+
+.job-layout {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1100px) {
+  .job-layout {
+    grid-template-columns: minmax(0, 1.7fr) minmax(240px, 0.9fr);
+    align-items: start;
+  }
+}
+
+.job-text-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.job-text {
+  min-height: 320px;
+  max-height: 540px;
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 16px;
+  padding: 1.1rem;
+  display: grid;
+  gap: 1rem;
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  font-size: 0.92rem;
+}
+
+.job-text .placeholder {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.job-text-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.job-meta {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.job-meta-list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.job-meta-list div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.88rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.job-meta-list dt {
+  margin: 0;
+  font-weight: 600;
+  color: rgba(226, 232, 255, 0.8);
+}
+
+.job-meta-list dd {
+  margin: 0;
+  text-align: right;
+}
+
+.job-links-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.job-links-list a {
+  color: #c7d2fe;
+  text-decoration: underline;
+  text-decoration-color: rgba(129, 140, 248, 0.6);
+}
+
+.job-links-list a:hover {
+  color: #f9fafb;
+}
+
+@media (min-width: 960px) {
+  .home-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-end;
   }
 }


### PR DESCRIPTION
## Summary
- reestructura la portada con cabecera accionable, métricas en tarjetas, tabla de recientes y controles de transcripción en vivo enlazados con el centro en vivo
- reorganiza la Biblioteca con breadcrumbs, sidebar de carpetas y filtros consolidados, añadiendo una plantilla de detalle de proceso con acciones de copia y descarga
- actualiza los estilos para el nuevo grid de Inicio, la tabla compacta, los indicadores en vivo y el panel maestro-detalle del Job Detail

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3feb0dfcc8321b147643170bc21d0