### PR TITLE
Fix theme toggle runtime error that broke UI buttons

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -527,14 +527,6 @@ function applyTheme(theme, persist = true) {
     } catch (error) {
       console.warn('No se pudo guardar el tema', error);
     }
-  });
-  if (persist) preferences.set(LOCAL_KEYS.lastRoute, normalized);
-  if (updateHash) {
-    const targetHash = `#${normalized}`;
-    if (window.location.hash !== targetHash) {
-      suppressHashChange = true;
-      window.location.hash = targetHash;
-    }
   }
   updateThemeToggle(normalized);
 }


### PR DESCRIPTION
## Summary
- clean up the theme application helper to only persist the selected theme
- remove stray navigation persistence logic so initialization no longer crashes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5231814848321b90e28e5d10469ea