### PR TITLE
Improve transcription detail streaming and downloads

### DIFF
--- a/app/routers/transcriptions.py
+++ b/app/routers/transcriptions.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import logging
+import mimetypes
 import secrets
 import shutil
 import time
@@ -754,6 +756,53 @@ def list_transcriptions(
 def get_transcription(transcription_id: int, session: Session = Depends(_get_session)) -> TranscriptionDetail:
     transcription = _get_transcription_or_404(session, transcription_id)
     return TranscriptionDetail.from_orm(transcription)
+
+
+@router.get("/{transcription_id}/audio")
+def download_transcription_audio(
+    transcription_id: int,
+    session: Session = Depends(_get_session),
+) -> FileResponse:
+    transcription = _get_transcription_or_404(session, transcription_id)
+    audio_path = Path(transcription.stored_path)
+    if not audio_path.exists():
+        raise HTTPException(status_code=404, detail="Audio original no disponible")
+    media_type, _ = mimetypes.guess_type(audio_path.name)
+    return FileResponse(
+        audio_path,
+        media_type=media_type or "application/octet-stream",
+        filename=audio_path.name,
+    )
+
+
+@router.get("/{transcription_id}/logs")
+def download_transcription_logs(
+    transcription_id: int,
+    session: Session = Depends(_get_session),
+) -> Response:
+    transcription = _get_transcription_or_404(session, transcription_id)
+    events = list(transcription.debug_events or [])
+    if not events:
+        content = "No hay eventos de depuración registrados aún.\n"
+    else:
+        lines: List[str] = []
+        for event in events:
+            timestamp = event.get("timestamp", "")
+            stage = event.get("stage", "")
+            level = event.get("level", "info")
+            message = event.get("message", "")
+            extra = event.get("extra")
+            lines.append(f"[{timestamp}] {level.upper()} · {stage}: {message}")
+            if extra:
+                formatted_extra = json.dumps(extra, ensure_ascii=False, sort_keys=True)
+                lines.append(f"    extra: {formatted_extra}")
+        content = "\n".join(lines) + "\n"
+    filename = f"transcription-{transcription_id}-logs.txt"
+    return Response(
+        content=content,
+        media_type="text/plain; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.get("/{transcription_id}/download")


### PR DESCRIPTION
## Summary
- expose new API endpoints to download original audio and debug logs for a transcription
- refresh the dashboard to consume /api/transcriptions, build folder metadata, and compute live stats from real data
- add polling so transcription text updates on screen while processing, and wire downloads to the new backend routes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54c3d5a0c832183187a215e99a045