### PR TITLE
Show live transcription progress and streaming updates

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -476,7 +476,7 @@
               <header class="panel__header">
                 <div>
                   <h2 class="panel__title" id="job-text-heading">Texto completo</h2>
-                  <p class="panel__subtitle">Streaming incremental con seguimiento automático.</p>
+                  <p class="panel__subtitle">Streaming incremental con progreso estimado en tiempo real.</p>
                 </div>
                 <div class="panel__actions">
                   <label class="field field--inline" for="job-tail-size">
@@ -491,6 +491,27 @@
                 </div>
               </header>
               <div class="job-text__body">
+                <div class="job-statusline" id="job-live-status" role="status" aria-live="polite">
+                  Selecciona una transcripción para ver el progreso.
+                </div>
+                <div class="job-progress" id="job-progress" hidden>
+                  <div class="job-progress__meta">
+                    <span id="job-progress-label">00:00 / 00:00</span>
+                    <span id="job-progress-eta">—</span>
+                  </div>
+                  <div
+                    class="job-progress__bar"
+                    id="job-progress-bar"
+                    role="progressbar"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    aria-valuenow="0"
+                    aria-labelledby="job-progress-label"
+                    aria-describedby="job-progress-eta"
+                  >
+                    <span class="job-progress__fill" id="job-progress-fill"></span>
+                  </div>
+                </div>
                 <div class="live-tail job-tail" id="job-tail" data-tail>
                   <pre class="live-tail__text" id="job-text-content">Elige una transcripción para verla aquí.</pre>
                 </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -371,6 +371,49 @@ html.dark .topbar {
   background: var(--job-bg);
 }
 
+.job-statusline {
+  font-size: 0.95rem;
+  color: var(--text-soft);
+}
+
+.job-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  color: var(--text-soft);
+}
+
+html.dark .job-progress {
+  background: rgba(17, 23, 42, 0.35);
+}
+
+.job-progress__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+}
+
+.job-progress__bar {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--border-strong);
+  overflow: hidden;
+}
+
+.job-progress__fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: linear-gradient(90deg, var(--primary), var(--primary-strong));
+  transition: width 0.4s ease;
+}
+
 .live-tail__text {
   white-space: pre-wrap;
   margin: 0;


### PR DESCRIPTION
## Summary
- estimate audio duration before transcription begins so progress calculations can use the analyze.duration event
- add job detail status and progress UI with ETA, cached partial text, and smoother tail scrolling
- derive incremental segments from debug events so the transcript streams in while updating stats and follow behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54c3d5a0c832183187a215e99a045