### PR TITLE
Improve live queue resilience and feedback

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -412,10 +412,19 @@
                   <span class="live-kpis__value" data-live-kpi="latency">0 ms</span>
                 </div>
                 <div>
+                  <span class="live-kpis__label">Cola en vivo</span>
+                  <span
+                    class="live-kpis__value live-kpis__value--badge"
+                    data-live-kpi="pending"
+                    aria-live="polite"
+                  >0</span>
+                </div>
+                <div>
                   <span class="live-kpis__label">Chunks perdidos</span>
                   <span class="live-kpis__value" data-live-kpi="dropped">0</span>
                 </div>
               </div>
+              <p class="live-alert" id="live-error-message" role="status" aria-live="polite" hidden></p>
               <div class="live-config__actions">
                 <button class="btn btn--secondary" id="live-start" type="button">Iniciar</button>
                 <button class="btn btn--ghost" id="live-pause" type="button" disabled>Pausar</button>
@@ -430,6 +439,19 @@
                     <select id="live-beam" class="field__input" data-default-beam="2"></select>
                   </label>
                   <p class="advanced__hint" id="live-beam-hint"></p>
+                  <label class="field">
+                    <span class="field__label">Intervalo de envío</span>
+                    <select id="live-chunk-interval" class="field__input">
+                      <option value="500">0,5 s</option>
+                      <option value="750">0,75 s</option>
+                      <option value="1000" selected>1 s</option>
+                      <option value="1500">1,5 s</option>
+                      <option value="2000">2 s</option>
+                    </select>
+                  </label>
+                  <p class="advanced__hint">
+                    Ajusta cada cuánto se envían fragmentos al servidor para equilibrar latencia y fiabilidad.
+                  </p>
                 </div>
                 <p class="advanced__note">Beam controla cuántas hipótesis de texto explora el modelo. Más beam = más calidad, pero también más retardo.</p>
               </details>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1201,6 +1201,48 @@ body.has-modal {
   font-weight: 600;
 }
 
+.live-kpis__value--badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--surface-alt);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.live-kpis__value--badge.is-active {
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+}
+
+.live-alert {
+  margin: 0.75rem 0 0;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(229, 72, 77, 0.18);
+  background: rgba(229, 72, 77, 0.08);
+  color: var(--danger);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+html.dark .live-kpis__value--badge {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+html.dark .live-kpis__value--badge.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+html.dark .live-alert {
+  border-color: rgba(240, 98, 114, 0.32);
+  background: rgba(240, 98, 114, 0.16);
+  color: #ffd1d7;
+}
+
 .job-grid {
   display: grid;
   gap: 2rem;


### PR DESCRIPTION
## Summary
- add retry/backoff handling for live chunk uploads with queue metrics that track the last successful send time
- surface live session errors through a new status banner and home status override while tightening transcript fallbacks
- keep the live backlog badge accessible and styled with the new alert block for quick backlog inspection

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e6a5d18f1c8321a2b171295a0836ae