### PR TITLE
Improve GPU selection and streaming progress feedback

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     whisper_enable_speaker_diarization: bool = True
     whisper_parallel_pipelines: int = 1
     whisper_word_timestamps: bool = False
-    whisper_condition_on_previous_text: bool = False
+    whisper_condition_on_previous_text: bool = True
     whisper_compression_ratio_threshold: Optional[float] = 2.4
     whisper_log_prob_threshold: Optional[float] = -1.0
     whisper_vad_repo_id: str = "pyannote/segmentation"

--- a/app/whisper_service.py
+++ b/app/whisper_service.py
@@ -30,12 +30,41 @@ try:  # pragma: no cover - faster_whisper is an optional dependency in CI
 except Exception:  # pragma: no cover - handled gracefully in runtime
     FasterWhisperModel = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency when GPU acceleration is available
+    import ctranslate2  # type: ignore
+except Exception:  # pragma: no cover - runtime environments without GPU support
+    ctranslate2 = None  # type: ignore
+
 from pydub import AudioSegment
 
 from .config import settings
 
 
 logger = logging.getLogger(__name__)
+
+
+def _torch_cuda_available() -> bool:
+    if torch is None:  # pragma: no cover - depends on optional dependency
+        return False
+    try:
+        return bool(torch.cuda.is_available())
+    except Exception:  # pragma: no cover - defensive, torch can raise on misconfiguration
+        return False
+
+
+def _ctranslate_cuda_available() -> bool:
+    if ctranslate2 is None:  # pragma: no cover - optional dependency
+        return False
+    try:
+        return bool(ctranslate2.get_cuda_device_count() > 0)
+    except Exception:  # pragma: no cover - defensive, CTranslate2 can raise
+        return False
+
+
+def is_cuda_runtime_available() -> bool:
+    """Return True when either torch or CTranslate2 can access a CUDA device."""
+
+    return _torch_cuda_available() or _ctranslate_cuda_available()
 
 
 DEFAULT_SUPPORTED_FASTER_WHISPER_KWARGS: Set[str] = {
@@ -470,10 +499,14 @@ class WhisperXTranscriber(BaseTranscriber):
             return "cpu"
         if settings.whisper_force_cuda:
             return "cuda"
-        if torch is not None and torch.cuda.is_available():
+        if is_cuda_runtime_available():
             return "cuda"
         logger.warning(
-            "CUDA solicitado pero no disponible; se usará CPU. Configure WHISPER_FORCE_CUDA=true para forzar GPU si su entorno lo soporta."
+            "CUDA solicitado pero no disponible; se usará CPU. Configure WHISPER_FORCE_CUDA=true para forzar GPU si su entorno lo soporta.",
+            extra={
+                "torch_cuda": _torch_cuda_available(),
+                "ctranslate2_cuda": _ctranslate_cuda_available(),
+            },
         )
         return "cpu"
 
@@ -511,7 +544,7 @@ class WhisperXTranscriber(BaseTranscriber):
             "compression_ratio_threshold": 2.4,
             "log_prob_threshold": -1.0,
             "no_speech_threshold": 0.6,
-            "condition_on_previous_text": False,
+            "condition_on_previous_text": settings.whisper_condition_on_previous_text,
             "prompt_reset_on_temperature": 0.5,
             "initial_prompt": None,
             "prefix": None,
@@ -772,9 +805,8 @@ class WhisperXTranscriber(BaseTranscriber):
         if self._model is None:
             preferred = self.device_preference or settings.whisper_device
             device = self._normalize_device(preferred)
-            forced_cuda = device == "cuda" and not (
-                torch is not None and torch.cuda.is_available()
-            ) and settings.whisper_force_cuda
+            runtime_cuda_available = is_cuda_runtime_available()
+            forced_cuda = device == "cuda" and settings.whisper_force_cuda and not runtime_cuda_available
             compute_type = self._compute_type_for_device(device)
             if forced_cuda:
                 logger.info("Forzando carga de whisperx %s en CUDA", self.model_size)
@@ -789,6 +821,8 @@ class WhisperXTranscriber(BaseTranscriber):
                         "device": device,
                         "compute_type": compute_type,
                         "forced_cuda": forced_cuda,
+                        "torch_cuda": _torch_cuda_available(),
+                        "ctranslate2_cuda": _ctranslate_cuda_available(),
                     },
                     "info",
                 )
@@ -969,7 +1003,8 @@ class WhisperXTranscriber(BaseTranscriber):
                 "CUDA no está disponible para WhisperX; se usará CPU",
                 {
                     "requested": self.device_preference or settings.whisper_device or "auto",
-                    "torch_cuda": bool(torch and torch.cuda.is_available()),
+                    "torch_cuda": _torch_cuda_available(),
+                    "ctranslate2_cuda": _ctranslate_cuda_available(),
                 },
                 "warning",
             )
@@ -1212,8 +1247,16 @@ class FasterWhisperTranscriber(BaseTranscriber):
         if preferred in {"cuda", "gpu"}:
             if settings.whisper_force_cuda:
                 return "cuda"
-            if torch is not None and torch.cuda.is_available():
+            if is_cuda_runtime_available():
                 return "cuda"
+            logger.warning(
+                "CUDA solicitado pero no disponible para faster-whisper; se usará CPU.",
+                extra={
+                    "requested": preferred,
+                    "torch_cuda": _torch_cuda_available(),
+                    "ctranslate2_cuda": _ctranslate_cuda_available(),
+                },
+            )
         return "cpu"
 
     def _current_device(self) -> str:
@@ -1275,7 +1318,7 @@ class FasterWhisperTranscriber(BaseTranscriber):
                 language=settings.whisper_language or "en",
                 beam_size=1,
                 temperature=0.0,
-                condition_on_previous_text=False,
+                condition_on_previous_text=settings.whisper_condition_on_previous_text,
                 vad_filter=False,
                 word_timestamps=False,
                 compression_ratio_threshold=None,
@@ -1355,7 +1398,9 @@ class FasterWhisperTranscriber(BaseTranscriber):
         requested_label = self.device_preference or settings.whisper_device or "auto"
         preferred = requested_label.lower()
         want_cuda = preferred in {"cuda", "gpu"}
-        torch_available = bool(torch and torch.cuda.is_available())
+        torch_available = _torch_cuda_available()
+        ctranslate_available = _ctranslate_cuda_available()
+        runtime_cuda_available = torch_available or ctranslate_available
 
         initial_device = self._resolve_device()
         if want_cuda and initial_device != "cuda":
@@ -1365,6 +1410,7 @@ class FasterWhisperTranscriber(BaseTranscriber):
                 {
                     "requested": requested_label,
                     "torch_cuda": torch_available,
+                    "ctranslate2_cuda": ctranslate_available,
                     "force_cuda": bool(settings.whisper_force_cuda),
                 },
                 "warning",
@@ -1382,7 +1428,7 @@ class FasterWhisperTranscriber(BaseTranscriber):
 
         for device in self._candidate_devices(initial_device):
             for compute_type in self._candidate_compute_types(device):
-                forced_cuda = device == "cuda" and settings.whisper_force_cuda and not torch_available
+                forced_cuda = device == "cuda" and settings.whisper_force_cuda and not runtime_cuda_available
                 emit(
                     "load-model",
                     "Cargando modelo faster-whisper de respaldo",
@@ -1393,6 +1439,8 @@ class FasterWhisperTranscriber(BaseTranscriber):
                         "cpu_threads": cpu_threads,
                         "num_workers": num_workers,
                         "forced_cuda": forced_cuda,
+                        "torch_cuda": torch_available,
+                        "ctranslate2_cuda": ctranslate_available,
                     },
                     "info",
                 )
@@ -1454,6 +1502,7 @@ class FasterWhisperTranscriber(BaseTranscriber):
                     "model": self.model_size,
                     "requested": requested_label,
                     "torch_cuda": torch_available,
+                    "ctranslate2_cuda": ctranslate_available,
                     "error": str(last_error) if last_error else None,
                 },
                 "error",
@@ -1476,6 +1525,7 @@ class FasterWhisperTranscriber(BaseTranscriber):
                 {
                     "requested": requested_label,
                     "torch_cuda": torch_available,
+                    "ctranslate2_cuda": ctranslate_available,
                 },
                 "warning",
             )

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,6 +4,7 @@ const LOCAL_KEYS = {
   liveFollow: 'grabadora:live-follow',
   jobFollow: 'grabadora:job-follow',
   liveTailSize: 'grabadora:live-tail-size',
+  liveChunkInterval: 'grabadora:live-chunk-interval',
   jobTailSize: 'grabadora:job-tail-size',
   lastRoute: 'grabadora:last-route',
 };
@@ -137,6 +138,10 @@ const WHISPER_MODELS = [
 const BEAM_OPTIONS = [1, 2, 3, 4, 5, 8];
 const DEFAULT_MODEL = 'large-v3';
 const NUMERIC_ID_PATTERN = /^\d+$/;
+const DEFAULT_LIVE_CHUNK_INTERVAL_MS = 1000;
+const LIVE_CHUNK_MAX_RETRIES = 3;
+const LIVE_CHUNK_RETRY_BASE_DELAY_MS = 250;
+const LIVE_CHUNK_RETRY_MAX_DELAY_MS = 4000;
 
 const PROMPT_TEXT = `Implementa sin desviar los siguientes puntos críticos en Grabadora Pro:\n\n1. Tema claro/oscuro con persistencia en localStorage y botón en el header.\n2. Formulario de subida que envíe multipart/form-data a POST /api/transcriptions (campo upload, destination_folder, language, model_size) con barra de progreso y manejo de 413.\n3. Al completar una subida, refrescar métricas básicas, mantener la cola local y avisar al usuario.\n4. Tail en vivo fijo al final con botón Volver al final y controles accesibles (pantalla completa, A+/A−).\n5. Biblioteca maestro-detalle con árbol de carpetas, filtros y breadcrumbs Inicio / Biblioteca / {Carpeta}.\n6. Detalle de proceso con streaming incremental, copiar texto y descargas .txt/.srt desde la API.\n7. Planes premium visibles (Estudiante, Starter, Pro) con características y CTA.\n8. Estados vacíos, errores accionables y toasts para eventos clave (inicio/fin/error).`;
 
@@ -345,10 +350,12 @@ const elements = {
     follow: document.getElementById('live-follow'),
     returnBtn: document.getElementById('live-return'),
     tailSize: document.getElementById('live-tail-size'),
+    chunkInterval: document.getElementById('live-chunk-interval'),
     fontPlus: document.getElementById('live-font-plus'),
     fontMinus: document.getElementById('live-font-minus'),
     fullscreen: document.getElementById('live-fullscreen'),
     kpis: document.querySelectorAll('[data-live-kpi]'),
+    error: document.getElementById('live-error-message'),
     beam: document.getElementById('live-beam'),
     beamHint: document.getElementById('live-beam-hint'),
     progress: document.getElementById('live-progress'),
@@ -425,6 +432,14 @@ const preferences = {
     }
   },
 };
+
+const initialLiveChunkInterval = (() => {
+  const stored = Number(preferences.get(LOCAL_KEYS.liveChunkInterval, NaN));
+  if (Number.isFinite(stored) && stored > 0) return stored;
+  const fromInput = Number(elements.live.chunkInterval?.value);
+  if (Number.isFinite(fromInput) && fromInput > 0) return fromInput;
+  return DEFAULT_LIVE_CHUNK_INTERVAL_MS;
+})();
 
 function getModelConfig(value) {
   const normalized = (value || '').toLowerCase();
@@ -716,6 +731,8 @@ function setupModelSelectors() {
   renderLiveStatus(initialLiveState);
   renderLiveKpis(initialLiveState);
   renderLiveProgress(initialLiveState);
+  renderHomeProgress(store.getState());
+  renderLiveError(initialLiveState);
 }
 
 function currentTheme() {
@@ -1021,6 +1038,10 @@ const store = createStore({
     droppedChunks: 0,
     error: null,
     isFinalizing: false,
+    chunkIntervalMs: initialLiveChunkInterval,
+    pendingChunks: 0,
+    lastChunkEnqueuedAt: null,
+    lastChunkSentAt: null,
   },
   job: {
     detail: null,
@@ -1137,11 +1158,11 @@ const liveSession = {
   sending: false,
   chunkIndex: 0,
   finishing: false,
+  chunkIntervalMs: null,
+  mimeType: null,
 };
 
 let liveProgressTimer = null;
-
-const LIVE_CHUNK_INTERVAL_MS = 2000;
 const LIVE_CHUNK_MIME_TYPES = [
   'audio/webm;codecs=opus',
   'audio/ogg;codecs=opus',
@@ -1156,6 +1177,82 @@ let modelPrepOverlaySession = null;
 function pickLiveMimeType() {
   if (!window.MediaRecorder || !window.MediaRecorder.isTypeSupported) return null;
   return LIVE_CHUNK_MIME_TYPES.find((type) => window.MediaRecorder.isTypeSupported(type)) || null;
+}
+
+function handleLiveRecorderData(event) {
+  if (event?.data && event.data.size) {
+    enqueueLiveChunk(event.data);
+  }
+}
+
+function handleLiveRecorderError(event) {
+  console.error('MediaRecorder error', event.error);
+  alert('Error al capturar audio en vivo. Se detendrá la sesión.');
+  finishLiveSession(true);
+}
+
+function attachLiveRecorder(recorder) {
+  recorder.addEventListener('dataavailable', handleLiveRecorderData);
+  recorder.addEventListener('error', handleLiveRecorderError);
+}
+
+async function restartLiveRecorder(intervalMs, { keepPaused = false } = {}) {
+  if (!liveSession.mediaStream) return false;
+  const previousRecorder = liveSession.recorder;
+  if (previousRecorder && previousRecorder.state !== 'inactive') {
+    await new Promise((resolve) => {
+      const handleStop = () => {
+        previousRecorder.removeEventListener('stop', handleStop);
+        resolve();
+      };
+      previousRecorder.addEventListener('stop', handleStop, { once: true });
+      try {
+        previousRecorder.stop();
+      } catch (error) {
+        console.warn('No se pudo detener el MediaRecorder para reiniciar', error);
+        previousRecorder.removeEventListener('stop', handleStop);
+        resolve();
+      }
+    });
+  }
+  try {
+    const options = liveSession.mimeType ? { mimeType: liveSession.mimeType } : undefined;
+    const recorder = new MediaRecorder(liveSession.mediaStream, options);
+    attachLiveRecorder(recorder);
+    liveSession.recorder = recorder;
+    liveSession.chunkIntervalMs = intervalMs;
+    if (keepPaused) {
+      recorder.addEventListener(
+        'start',
+        () => {
+          if (typeof recorder.pause === 'function') {
+            try {
+              recorder.pause();
+            } catch (error) {
+              console.warn('No se pudo pausar el MediaRecorder tras reinicio', error);
+            }
+          }
+        },
+        { once: true },
+      );
+    }
+    recorder.start(intervalMs);
+    store.setState((prev) => {
+      if (prev.live.chunkIntervalMs === intervalMs) return prev;
+      return {
+        ...prev,
+        live: {
+          ...prev.live,
+          chunkIntervalMs: intervalMs,
+        },
+      };
+    });
+    return true;
+  } catch (error) {
+    console.error('No se pudo reiniciar el MediaRecorder', error);
+    alert('No se pudo aplicar el nuevo intervalo de fragmentos.');
+    return false;
+  }
 }
 
 function formatDeviceLabel(device) {
@@ -1339,6 +1436,9 @@ function resetLiveSessionLocalState() {
   liveSession.chunkIndex = 0;
   liveSession.finishing = false;
   liveSession.sessionId = null;
+  liveSession.chunkIntervalMs = null;
+  liveSession.mimeType = null;
+  updateLiveQueueMetrics({ lastChunkEnqueuedAt: null, lastChunkSentAt: null });
 }
 
 async function discardRemoteLiveSession(sessionId) {
@@ -1771,12 +1871,13 @@ function renderLiveTail(liveState) {
     tailControllers.live.render('Conecta el micro para comenzar.');
     return;
   }
-  const hasText = typeof liveState.text === 'string' && liveState.text.trim();
-  const fromSegments = Array.isArray(liveState.segments) && liveState.segments.length
-    ? liveState.segments.join('')
+  const trimmedText = typeof liveState.text === 'string' ? liveState.text.trim() : '';
+  const segmentsJoined = Array.isArray(liveState.segments) && liveState.segments.length
+    ? liveState.segments.join(' ')
     : '';
-  const content = hasText ? liveState.text : fromSegments || 'Conecta el micro para comenzar.';
-  tailControllers.live.render(content);
+  const trimmedSegments = typeof segmentsJoined === 'string' ? segmentsJoined.trim() : '';
+  const content = trimmedText || trimmedSegments;
+  tailControllers.live.render(content || 'Conecta el micro para comenzar.');
 }
 
 function computeLiveStatusMessage(liveState) {
@@ -1856,16 +1957,21 @@ function renderHomePanel(state) {
     }
     return;
   }
-  const liveContent = live.text && live.text.trim()
-    ? live.text
-    : live.segments.length
-    ? live.segments.join('')
-    : 'Inicia una sesión para ver la transcripción en directo.';
-  tailControllers.home.render(liveContent);
+  const liveText = typeof live.text === 'string' ? live.text.trim() : '';
+  const liveSegments = Array.isArray(live.segments) && live.segments.length
+    ? live.segments.join(' ')
+    : '';
+  const liveContent = (liveText || liveSegments).trim();
+  tailControllers.home.render(liveContent || 'Inicia una sesión para ver la transcripción en directo.');
 }
 
 function updateHomeStatus(state) {
   if (!elements.home.status) return;
+  const liveError = typeof state.live?.error === 'string' ? state.live.error.trim() : '';
+  if (liveError) {
+    elements.home.status.textContent = `⚠️ ${liveError}`;
+    return;
+  }
   const stream = state.stream;
   if (stream?.jobId) {
     let message = '';
@@ -1876,8 +1982,9 @@ function updateHomeStatus(state) {
     if (jobForProgress) {
       const info = computeJobProgressState(jobForProgress, debugEvents);
       if (info?.statusText) {
-        message = info.statusText;
-        if (info.etaText && info.percent != null && info.percent < 1) {
+        const percentValue = info.percent != null ? Math.round(info.percent * 100) : null;
+        message = percentValue != null ? `${percentValue}% · ${info.statusText}` : info.statusText;
+        if (info.etaText && (info.percent == null || info.percent < 1)) {
           message += ` · ${info.etaText}`;
         }
       }
@@ -1927,27 +2034,7 @@ function renderLiveStatus(liveState) {
   if (elements.live.finish) elements.live.finish.disabled = isIdle || isFinalizing;
 }
 
-function renderLiveProgress(liveState) {
-  const widgets = [
-    {
-      container: elements.home.progress,
-      label: elements.home.progressLabel,
-      rate: elements.home.progressRate,
-      fill: elements.home.progressFill,
-      bar: elements.home.progressBar,
-      percent: elements.home.progressPercent,
-      remaining: elements.home.progressRemaining,
-    },
-    {
-      container: elements.live.progress,
-      label: elements.live.progressLabel,
-      rate: elements.live.progressRate,
-      fill: elements.live.progressFill,
-      bar: elements.live.progressBar,
-      percent: elements.live.progressPercent,
-      remaining: elements.live.progressRemaining,
-    },
-  ];
+function computeLiveProgressMetrics(liveState) {
   const status = liveState?.status || 'idle';
   const processedSeconds = Number.isFinite(liveState?.duration)
     ? Math.max(0, liveState.duration)
@@ -1968,51 +2055,145 @@ function renderLiveProgress(liveState) {
   if (elapsedMs < 0) elapsedMs = 0;
   const elapsedSeconds = elapsedMs / 1000;
   const shouldShow = ['recording', 'paused', 'finalizing'].includes(status) || processedSeconds > 0;
-  widgets.forEach((widget) => {
-    if (!widget?.container) return;
-    if (!shouldShow) {
-      widget.container.hidden = true;
-      if (widget.fill) widget.fill.style.width = '0%';
-      widget.bar?.setAttribute('aria-valuenow', '0');
-      if (widget.percent) widget.percent.textContent = '0%';
-      if (widget.label) widget.label.textContent = '00:00 procesados';
-      if (widget.rate) widget.rate.textContent = 'Esperando audio…';
-      if (widget.remaining) widget.remaining.textContent = 'Restante —';
-      return;
+  if (!shouldShow) {
+    return { shouldShow: false, status };
+  }
+  const processed = processedSeconds > 0 ? processedSeconds : elapsedSeconds;
+  const ratio = elapsedSeconds > 0 ? Math.min(1, processed / elapsedSeconds) : processed > 0 ? 1 : 0;
+  const percentValue = Math.round(ratio * 100);
+  let rateText = '';
+  if (status === 'paused') {
+    rateText = 'Grabación en pausa';
+  } else if (status === 'finalizing') {
+    rateText = 'Guardando sesión…';
+  } else if (status === 'completed') {
+    rateText = 'Sesión finalizada';
+  } else if (elapsedSeconds <= 0 && processedSeconds <= 0) {
+    rateText = 'Esperando audio…';
+  } else if (ratio >= 1) {
+    rateText = 'Al día en tiempo real';
+  } else {
+    const lag = Math.max(0, elapsedSeconds - processed);
+    rateText = lag > 1 ? `Retraso ${formatClock(lag)}` : 'Procesando…';
+  }
+  const remainingText = ratio >= 1
+    ? 'Sin retraso pendiente'
+    : `Restante ${formatClock(Math.max(0, elapsedSeconds - processed))}`;
+  return {
+    shouldShow: true,
+    status,
+    percentValue,
+    label: `${formatClock(processed)} procesados`,
+    rateText,
+    remainingText,
+    ratio,
+    processedSeconds,
+    elapsedSeconds,
+  };
+}
+
+function renderLiveProgress(liveState) {
+  const widget = {
+    container: elements.live.progress,
+    label: elements.live.progressLabel,
+    rate: elements.live.progressRate,
+    fill: elements.live.progressFill,
+    bar: elements.live.progressBar,
+    percent: elements.live.progressPercent,
+    remaining: elements.live.progressRemaining,
+  };
+  if (!widget.container) return;
+  const metrics = computeLiveProgressMetrics(liveState);
+  if (!metrics.shouldShow) {
+    widget.container.hidden = true;
+    if (widget.fill) {
+      widget.fill.style.width = '0%';
+      widget.fill.classList.remove('is-indeterminate');
     }
+    widget.bar?.setAttribute('aria-valuenow', '0');
+    if (widget.percent) widget.percent.textContent = '0%';
+    if (widget.label) widget.label.textContent = '00:00 procesados';
+    if (widget.rate) widget.rate.textContent = 'Esperando audio…';
+    if (widget.remaining) widget.remaining.textContent = 'Restante —';
+    return;
+  }
+  widget.container.hidden = false;
+  if (widget.fill) {
+    widget.fill.style.width = `${metrics.percentValue}%`;
+    widget.fill.classList.remove('is-indeterminate');
+  }
+  widget.bar?.setAttribute('aria-valuenow', String(metrics.percentValue));
+  if (widget.percent) widget.percent.textContent = `${metrics.percentValue}%`;
+  if (widget.label) widget.label.textContent = metrics.label;
+  if (widget.rate) widget.rate.textContent = metrics.rateText;
+  if (widget.remaining) widget.remaining.textContent = metrics.remainingText;
+}
+
+function renderHomeProgress(state) {
+  const widget = {
+    container: elements.home.progress,
+    label: elements.home.progressLabel,
+    rate: elements.home.progressRate,
+    fill: elements.home.progressFill,
+    bar: elements.home.progressBar,
+    percent: elements.home.progressPercent,
+    remaining: elements.home.progressRemaining,
+  };
+  if (!widget.container) return;
+
+  const stream = state.stream;
+  if (stream?.jobId) {
+    const jobIdStr = String(stream.jobId);
+    const debugEvents = Array.isArray(stream.debugEvents) ? stream.debugEvents : [];
+    const detailedJob = state.job.detail?.job && String(state.job.detail.job.id) === jobIdStr
+      ? state.job.detail.job
+      : null;
+    const listJob = state.jobs.find((job) => String(job.id) === jobIdStr) || null;
+    const job = detailedJob || listJob;
+    const info = job ? computeJobProgressState(job, debugEvents) : null;
+    const percentValue = info && info.showBar && info.percent != null
+      ? Math.max(0, Math.min(100, Math.round(info.percent * 100)))
+      : null;
     widget.container.hidden = false;
-    const processed = processedSeconds > 0 ? processedSeconds : elapsedSeconds;
-    const ratio = elapsedSeconds > 0 ? Math.min(1, processed / elapsedSeconds) : processed > 0 ? 1 : 0;
-    const percentValue = Math.round(ratio * 100);
-    if (widget.label) widget.label.textContent = `${formatClock(processed)} procesados`;
-    if (widget.percent) widget.percent.textContent = `${percentValue}%`;
-    if (widget.fill) widget.fill.style.width = `${percentValue}%`;
-    widget.bar?.setAttribute('aria-valuenow', String(percentValue));
-    let rateText = '';
-    if (status === 'paused') {
-      rateText = 'Grabación en pausa';
-    } else if (status === 'finalizing') {
-      rateText = 'Guardando sesión…';
-    } else if (status === 'completed') {
-      rateText = 'Sesión finalizada';
-    } else if (elapsedSeconds <= 0 && processedSeconds <= 0) {
-      rateText = 'Esperando audio…';
-    } else if (ratio >= 1) {
-      rateText = 'Al día en tiempo real';
-    } else {
-      const lag = Math.max(0, elapsedSeconds - processed);
-      rateText = lag > 1 ? `Retraso ${formatClock(lag)}` : 'Procesando…';
+    if (widget.fill) {
+      widget.fill.style.width = percentValue != null ? `${percentValue}%` : '28%';
+      widget.fill.classList.toggle('is-indeterminate', percentValue == null);
     }
-    if (widget.rate) widget.rate.textContent = rateText;
-    if (widget.remaining) {
-      if (ratio >= 1) {
-        widget.remaining.textContent = 'Sin retraso pendiente';
-      } else {
-        const remainingSeconds = Math.max(0, elapsedSeconds - processed);
-        widget.remaining.textContent = `Restante ${formatClock(remainingSeconds)}`;
-      }
+    widget.bar?.setAttribute('aria-valuenow', String(percentValue != null ? percentValue : 0));
+    if (widget.percent) widget.percent.textContent = percentValue != null ? `${percentValue}%` : '—';
+    const fallbackLabel = stream.jobName ? `Transcribiendo ${stream.jobName}` : 'Transcribiendo…';
+    if (widget.label) widget.label.textContent = info?.label || fallbackLabel;
+    const statusText = info?.statusText || computeStreamStatusMessage(stream) || fallbackLabel;
+    if (widget.rate) widget.rate.textContent = statusText;
+    if (widget.remaining) widget.remaining.textContent = info?.etaText || 'Calculando tiempo restante…';
+    return;
+  }
+
+  const metrics = computeLiveProgressMetrics(state.live);
+  if (!metrics.shouldShow) {
+    widget.container.hidden = true;
+    if (widget.fill) {
+      widget.fill.style.width = '0%';
+      widget.fill.classList.remove('is-indeterminate');
     }
-  });
+    widget.bar?.setAttribute('aria-valuenow', '0');
+    if (widget.percent) widget.percent.textContent = '0%';
+    if (widget.label) widget.label.textContent = '00:00 procesados';
+    if (widget.rate) widget.rate.textContent = 'Esperando audio…';
+    if (widget.remaining) widget.remaining.textContent = 'Restante —';
+    return;
+  }
+
+  widget.container.hidden = false;
+  if (widget.fill) {
+    widget.fill.style.width = `${metrics.percentValue}%`;
+    widget.fill.classList.remove('is-indeterminate');
+  }
+  widget.bar?.setAttribute('aria-valuenow', String(metrics.percentValue));
+  if (widget.percent) widget.percent.textContent = `${metrics.percentValue}%`;
+  if (widget.label) widget.label.textContent = metrics.label;
+  if (widget.rate) widget.rate.textContent = metrics.rateText;
+  if (widget.remaining) widget.remaining.textContent = metrics.remainingText;
 }
 
 function buildSegmentsFromEvents(events) {
@@ -2361,6 +2542,19 @@ store.subscribe((state, prev) => {
   }
   if (
     state.stream !== prev.stream ||
+    state.live.duration !== prev.live.duration ||
+    state.live.runtimeSeconds !== prev.live.runtimeSeconds ||
+    state.live.startedAt !== prev.live.startedAt ||
+    state.live.pauseStartedAt !== prev.live.pauseStartedAt ||
+    state.live.totalPausedMs !== prev.live.totalPausedMs ||
+    state.live.status !== prev.live.status ||
+    state.jobs !== prev.jobs ||
+    state.job.detail !== prev.job.detail
+  ) {
+    renderHomeProgress(state);
+  }
+  if (
+    state.stream !== prev.stream ||
     state.live.text !== prev.live.text ||
     state.live.segments !== prev.live.segments
   ) {
@@ -2370,16 +2564,21 @@ store.subscribe((state, prev) => {
     state.stream !== prev.stream ||
     state.live.status !== prev.live.status ||
     state.live.isFinalizing !== prev.live.isFinalizing ||
-    state.live.text !== prev.live.text
+    state.live.text !== prev.live.text ||
+    state.live.error !== prev.live.error
   ) {
     updateHomeStatus(state);
   }
   if (
     state.live.latencyMs !== prev.live.latencyMs ||
     state.live.wpm !== prev.live.wpm ||
-    state.live.droppedChunks !== prev.live.droppedChunks
+    state.live.droppedChunks !== prev.live.droppedChunks ||
+    state.live.pendingChunks !== prev.live.pendingChunks
   ) {
     renderLiveKpis(state.live);
+  }
+  if (state.live.error !== prev.live.error) {
+    renderLiveError(state.live);
   }
   if (state.job.detail !== prev.job.detail || state.job.maxSegments !== prev.job.maxSegments) {
     renderJobDetail(state);
@@ -3109,11 +3308,62 @@ function renderLiveKpis(liveState) {
     : '—';
   const wpmText = Number.isFinite(liveState.wpm) && liveState.wpm > 0 ? String(liveState.wpm) : '0';
   const droppedText = Number.isFinite(liveState.droppedChunks) ? String(liveState.droppedChunks) : '0';
+  const pendingCount = Number.isFinite(liveState.pendingChunks) && liveState.pendingChunks >= 0
+    ? liveState.pendingChunks
+    : 0;
+  const pendingText = String(pendingCount);
   elements.live.kpis.forEach((node) => {
     const metric = node.dataset.liveKpi;
     if (metric === 'wpm') node.textContent = wpmText;
     if (metric === 'latency') node.textContent = latencyText;
     if (metric === 'dropped') node.textContent = droppedText;
+    if (metric === 'pending') {
+      node.textContent = pendingText;
+      node.classList.toggle('is-active', pendingCount > 0);
+      const labelUnit = pendingCount === 1 ? 'fragmento' : 'fragmentos';
+      const labelText = pendingCount > 0 ? `${pendingCount} ${labelUnit} en cola` : 'Sin fragmentos pendientes';
+      node.setAttribute('aria-label', labelText);
+      node.setAttribute('title', labelText);
+    }
+  });
+}
+
+function renderLiveError(liveState) {
+  const message = typeof liveState?.error === 'string' ? liveState.error.trim() : '';
+  const target = elements.live.error;
+  if (!target) return;
+  if (message) {
+    target.textContent = message;
+    target.hidden = false;
+  } else {
+    target.textContent = '';
+    target.hidden = true;
+  }
+}
+
+function updateLiveQueueMetrics(overrides = {}) {
+  store.setState((prev) => {
+    const pendingChunks = Math.max(0, liveSession.chunkQueue.length + (liveSession.sending ? 1 : 0));
+    let changed = false;
+    const nextLive = { ...prev.live };
+    if (nextLive.pendingChunks !== pendingChunks) {
+      nextLive.pendingChunks = pendingChunks;
+      changed = true;
+    }
+    if (Object.prototype.hasOwnProperty.call(overrides, 'lastChunkEnqueuedAt')) {
+      if (nextLive.lastChunkEnqueuedAt !== overrides.lastChunkEnqueuedAt) {
+        nextLive.lastChunkEnqueuedAt = overrides.lastChunkEnqueuedAt;
+        changed = true;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(overrides, 'lastChunkSentAt')) {
+      if (nextLive.lastChunkSentAt !== overrides.lastChunkSentAt) {
+        nextLive.lastChunkSentAt = overrides.lastChunkSentAt;
+        changed = true;
+      }
+    }
+    if (!changed) return prev;
+    return { ...prev, live: nextLive };
   });
 }
 
@@ -3121,7 +3371,9 @@ function enqueueLiveChunk(blob) {
   if (!blob || !blob.size || !liveSession.sessionId) return;
   const index = liveSession.chunkIndex;
   liveSession.chunkIndex += 1;
-  liveSession.chunkQueue.push({ blob, index, createdAt: Date.now() });
+  const createdAt = Date.now();
+  liveSession.chunkQueue.push({ blob, index, createdAt, attempts: 0 });
+  updateLiveQueueMetrics({ lastChunkEnqueuedAt: createdAt });
   processLiveChunkQueue();
 }
 
@@ -3129,11 +3381,16 @@ async function processLiveChunkQueue() {
   if (liveSession.sending) return;
   if (!liveSession.sessionId) {
     liveSession.chunkQueue = [];
+    updateLiveQueueMetrics();
     return;
   }
   const item = liveSession.chunkQueue.shift();
-  if (!item) return;
+  if (!item) {
+    updateLiveQueueMetrics();
+    return;
+  }
   liveSession.sending = true;
+  updateLiveQueueMetrics();
   const endpoint = `/api/transcriptions/live/sessions/${liveSession.sessionId}/chunk`;
   try {
     const formData = new FormData();
@@ -3154,19 +3411,38 @@ async function processLiveChunkQueue() {
       throw new Error(message);
     }
     const payload = await response.json();
+    updateLiveQueueMetrics({ lastChunkSentAt: Date.now() });
     handleLiveChunkPayload(payload, Date.now() - item.createdAt);
   } catch (error) {
     console.error('Error al enviar fragmento en vivo', error);
-    store.setState((prev) => ({
-      ...prev,
-      live: {
-        ...prev.live,
-        droppedChunks: prev.live.droppedChunks + 1,
-        error: error?.message || 'No se pudo enviar el fragmento en vivo.',
-      },
-    }));
+    const attempts = (item.attempts || 0) + 1;
+    const message = error?.message || 'No se pudo enviar el fragmento en vivo.';
+    if (attempts <= LIVE_CHUNK_MAX_RETRIES && liveSession.sessionId) {
+      item.attempts = attempts;
+      liveSession.chunkQueue.unshift(item);
+      store.setState((prev) => ({
+        ...prev,
+        live: {
+          ...prev.live,
+          error: `${message} Reintentando (${attempts}/${LIVE_CHUNK_MAX_RETRIES})…`,
+        },
+      }));
+      const backoff = Math.min(LIVE_CHUNK_RETRY_BASE_DELAY_MS * attempts * attempts, LIVE_CHUNK_RETRY_MAX_DELAY_MS);
+      await delay(backoff);
+    } else {
+      store.setState((prev) => ({
+        ...prev,
+        live: {
+          ...prev.live,
+          droppedChunks: prev.live.droppedChunks + 1,
+          error: message,
+        },
+      }));
+      updateLiveQueueMetrics({ lastChunkSentAt: Date.now() });
+    }
   } finally {
     liveSession.sending = false;
+    updateLiveQueueMetrics();
     if (liveSession.chunkQueue.length) {
       processLiveChunkQueue();
     }
@@ -3285,7 +3561,16 @@ async function startLiveSession() {
     const sessionInfo = await response.json();
     const mimeType = pickLiveMimeType();
     const options = mimeType ? { mimeType } : undefined;
+    const desiredInterval = Number(elements.live.chunkInterval?.value)
+      || store.getState().live.chunkIntervalMs
+      || initialLiveChunkInterval;
+    const chunkIntervalMs = Number.isFinite(desiredInterval) && desiredInterval > 0
+      ? desiredInterval
+      : DEFAULT_LIVE_CHUNK_INTERVAL_MS;
     const recorder = new MediaRecorder(audioStream, options);
+    if (elements.live.chunkInterval) {
+      elements.live.chunkInterval.value = String(chunkIntervalMs);
+    }
     liveSession.sessionId = sessionInfo.session_id;
     liveSession.mediaStream = audioStream;
     liveSession.recorder = recorder;
@@ -3293,19 +3578,13 @@ async function startLiveSession() {
     liveSession.chunkIndex = 0;
     liveSession.sending = false;
     liveSession.finishing = false;
+    liveSession.chunkIntervalMs = chunkIntervalMs;
+    liveSession.mimeType = mimeType || null;
 
-    recorder.addEventListener('dataavailable', (event) => {
-      if (event.data && event.data.size) {
-        enqueueLiveChunk(event.data);
-      }
-    });
-    recorder.addEventListener('error', (event) => {
-      console.error('MediaRecorder error', event.error);
-      alert('Error al capturar audio en vivo. Se detendrá la sesión.');
-      finishLiveSession(true);
-    });
-
-    recorder.start(LIVE_CHUNK_INTERVAL_MS);
+    preferences.set(LOCAL_KEYS.liveChunkInterval, chunkIntervalMs);
+    attachLiveRecorder(recorder);
+    recorder.start(chunkIntervalMs);
+    updateLiveQueueMetrics({ lastChunkEnqueuedAt: null, lastChunkSentAt: null });
 
     store.setState((prev) => ({
       ...prev,
@@ -3330,6 +3609,10 @@ async function startLiveSession() {
         droppedChunks: 0,
         error: null,
         isFinalizing: false,
+        chunkIntervalMs,
+        pendingChunks: 0,
+        lastChunkEnqueuedAt: null,
+        lastChunkSentAt: null,
       },
     }));
     renderLiveKpis(store.getState().live);
@@ -3385,13 +3668,26 @@ function pauseLiveSession() {
   }));
 }
 
-function resumeLiveSession() {
+async function resumeLiveSession() {
   const state = store.getState().live;
-  if (state.status !== 'paused' || !liveSession.recorder) return;
+  if (state.status !== 'paused') return;
   updatePausedMetrics();
-  if (typeof liveSession.recorder.resume === 'function' && liveSession.recorder.state === 'paused') {
+  const desiredInterval = Number(state.chunkIntervalMs) || DEFAULT_LIVE_CHUNK_INTERVAL_MS;
+  if (
+    liveSession.recorder &&
+    liveSession.sessionId &&
+    Number.isFinite(desiredInterval) &&
+    desiredInterval > 0 &&
+    desiredInterval !== liveSession.chunkIntervalMs
+  ) {
+    const restarted = await restartLiveRecorder(desiredInterval, { keepPaused: true });
+    if (!restarted) return;
+  }
+  const recorder = liveSession.recorder;
+  if (!recorder) return;
+  if (recorder && typeof recorder.resume === 'function' && recorder.state === 'paused') {
     try {
-      liveSession.recorder.resume();
+      recorder.resume();
     } catch (error) {
       console.warn('No se pudo reanudar el MediaRecorder', error);
     }
@@ -3647,6 +3943,43 @@ function setupLiveControls() {
   bind(elements.home.finish, 'click', finishLiveSession);
   bind(elements.live.finish, 'click', finishLiveSession);
 
+  if (elements.live.chunkInterval) {
+    const currentInterval = store.getState().live.chunkIntervalMs || initialLiveChunkInterval;
+    elements.live.chunkInterval.value = String(currentInterval);
+    elements.live.chunkInterval.addEventListener('change', async (event) => {
+      const raw = Number(event.target.value);
+      const value = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_LIVE_CHUNK_INTERVAL_MS;
+      preferences.set(LOCAL_KEYS.liveChunkInterval, value);
+      store.setState((prev) => ({
+        ...prev,
+        live: {
+          ...prev.live,
+          chunkIntervalMs: value,
+        },
+      }));
+      const shouldRestart = Boolean(liveSession.recorder && liveSession.sessionId);
+      if (!shouldRestart) {
+        liveSession.chunkIntervalMs = value;
+        return;
+      }
+      if (value === liveSession.chunkIntervalMs) return;
+      const keepPaused = store.getState().live.status === 'paused';
+      const success = await restartLiveRecorder(value, { keepPaused });
+      if (!success) {
+        const fallback = liveSession.chunkIntervalMs || store.getState().live.chunkIntervalMs || DEFAULT_LIVE_CHUNK_INTERVAL_MS;
+        event.target.value = String(fallback);
+        store.setState((prev) => ({
+          ...prev,
+          live: {
+            ...prev.live,
+            chunkIntervalMs: fallback,
+          },
+        }));
+        preferences.set(LOCAL_KEYS.liveChunkInterval, fallback);
+      }
+    });
+  }
+
   if (elements.live.tailSize) {
     elements.live.tailSize.value = String(store.getState().live.maxSegments);
     elements.live.tailSize.addEventListener('change', (event) => {
@@ -3754,10 +4087,14 @@ function setupDiagnostics() {
 function setupLiveProgressTicker() {
   if (liveProgressTimer) return;
   liveProgressTimer = window.setInterval(() => {
-    const liveState = store.getState().live;
+    const state = store.getState();
+    const liveState = state.live;
     if (!liveState) return;
     if (['recording', 'paused', 'finalizing'].includes(liveState.status)) {
       renderLiveProgress(liveState);
+      if (!state.stream?.jobId) {
+        renderHomeProgress(state);
+      }
     }
   }, 1000);
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -412,10 +412,19 @@
                   <span class="live-kpis__value" data-live-kpi="latency">0 ms</span>
                 </div>
                 <div>
+                  <span class="live-kpis__label">Cola en vivo</span>
+                  <span
+                    class="live-kpis__value live-kpis__value--badge"
+                    data-live-kpi="pending"
+                    aria-live="polite"
+                  >0</span>
+                </div>
+                <div>
                   <span class="live-kpis__label">Chunks perdidos</span>
                   <span class="live-kpis__value" data-live-kpi="dropped">0</span>
                 </div>
               </div>
+              <p class="live-alert" id="live-error-message" role="status" aria-live="polite" hidden></p>
               <div class="live-config__actions">
                 <button class="btn btn--secondary" id="live-start" type="button">Iniciar</button>
                 <button class="btn btn--ghost" id="live-pause" type="button" disabled>Pausar</button>
@@ -430,6 +439,19 @@
                     <select id="live-beam" class="field__input" data-default-beam="2"></select>
                   </label>
                   <p class="advanced__hint" id="live-beam-hint"></p>
+                  <label class="field">
+                    <span class="field__label">Intervalo de envío</span>
+                    <select id="live-chunk-interval" class="field__input">
+                      <option value="500">0,5 s</option>
+                      <option value="750">0,75 s</option>
+                      <option value="1000" selected>1 s</option>
+                      <option value="1500">1,5 s</option>
+                      <option value="2000">2 s</option>
+                    </select>
+                  </label>
+                  <p class="advanced__hint">
+                    Ajusta cada cuánto se envían fragmentos al servidor para equilibrar latencia y fiabilidad.
+                  </p>
                 </div>
                 <p class="advanced__note">Beam controla cuántas hipótesis de texto explora el modelo. Más beam = más calidad, pero también más retardo.</p>
               </details>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -417,6 +417,12 @@ html.dark .job-progress {
   transition: width 0.4s ease;
 }
 
+.job-progress__fill.is-indeterminate,
+.live-progress__fill.is-indeterminate {
+  animation: progress-stripes 1.2s linear infinite;
+  background-size: 200% 100%;
+}
+
 .live-panel__status-area {
   display: flex;
   flex-direction: column;
@@ -472,6 +478,15 @@ html.dark .live-progress {
   width: 0%;
   background: linear-gradient(90deg, var(--primary), var(--primary-strong));
   transition: width 0.4s ease;
+}
+
+@keyframes progress-stripes {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: -200% 50%;
+  }
 }
 
 .live-progress__status {
@@ -1199,6 +1214,48 @@ body.has-modal {
 .live-kpis__value {
   font-size: 1.2rem;
   font-weight: 600;
+}
+
+.live-kpis__value--badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--surface-alt);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.live-kpis__value--badge.is-active {
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+}
+
+.live-alert {
+  margin: 0.75rem 0 0;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(229, 72, 77, 0.18);
+  background: rgba(229, 72, 77, 0.08);
+  color: var(--danger);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+html.dark .live-kpis__value--badge {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+html.dark .live-kpis__value--badge.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+html.dark .live-alert {
+  border-color: rgba(240, 98, 114, 0.32);
+  background: rgba(240, 98, 114, 0.16);
+  color: #ffd1d7;
 }
 
 .job-grid {


### PR DESCRIPTION
## Summary
- expand GPU detection to consider CTranslate2 availability, surface the result through device resolution, and default Whisper decoding to condition on previous text to reduce repetitions
- refresh the home/live progress widgets to expose explicit percent and ETA updates with periodic refreshes and an indeterminate animation when totals are unknown

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e6a5d18f1c8321a2b171295a0836ae